### PR TITLE
Release 0.6.0

### DIFF
--- a/.github/workflows/publish-dockerimage.yml
+++ b/.github/workflows/publish-dockerimage.yml
@@ -28,7 +28,7 @@ jobs:
           - ubuntu-24.04-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -36,7 +36,7 @@ jobs:
           echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -87,7 +87,7 @@ jobs:
           - "19.0"
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: 'Download artifacts for amd64'
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,66 @@ jobs:
           path: |
             build/odood_${{ steps.check-arch.outputs.arch }}.deb
 
+  build-docs-pdf:
+    name: Build Docs PDF
+    runs-on: ubuntu-22.04
+    env:
+      MDBOOK_VERSION: 0.5.2
+      MDBOOK_PDF_VERSION: 0.1.9
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install D compiler
+        uses: dlang-community/setup-dlang@v1
+        with:
+          compiler: ${{ env.ODOOD_DLANG_COMPILER }}
+
+      - name: Install system dependencies
+        uses: lyricwulf/abc@v1
+        with:
+          linux: libzip-dev libpq-dev python3-dev
+
+      - name: Set version from tag
+        run: echo "${{ github.ref_name }}" > ./subpackages/lib/data/ODOOD_VERSION
+
+      - name: Build Odood command reference
+        run: dub build -c generate-command-ref
+
+      - name: Prepare docs sources
+        run: |
+          cp build/odood-docs-command-ref.md docs/odood/src/odood-docs-command-ref.md
+          cp -f ./CHANGELOG.md ./docs/odood/src/changelog.md
+          # Append PDF output backend to book.toml for this build only.
+          # When multiple outputs are configured mdBook places each in its own
+          # subdirectory: book/html/ for HTML, book/pdf/ for PDF.
+          printf '\n[output.pdf]\n' >> docs/odood/book.toml
+
+      - name: Cache cargo
+        id: cache-cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ~/.cargo/bin/mdbook
+            ~/.cargo/bin/mdbook-pdf
+          key: cargo-mdbook-${{ env.MDBOOK_VERSION }}-pdf-${{ env.MDBOOK_PDF_VERSION }}
+
+      - name: Install mdBook and mdbook-pdf
+        if: steps.cache-cargo.outputs.cache-hit != 'true'
+        run: |
+          cargo install --version ${MDBOOK_VERSION} mdbook
+          cargo install --version ${MDBOOK_PDF_VERSION} mdbook-pdf
+
+      - name: Build docs
+        run: mdbook build ./docs/odood
+
+      - name: Upload docs PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: odood-docs-pdf
+          path: docs/odood/book/pdf/output.pdf
+
   publish_release:
     name: Publish Release
     runs-on: ubuntu-22.04
@@ -86,6 +146,7 @@ jobs:
       contents: write
     needs:
       - build-ubuntu
+      - build-docs-pdf
     steps:
       - uses: actions/checkout@v3
 
@@ -100,6 +161,12 @@ jobs:
         with:
           name: odood-arm64
           path: build-arm64
+
+      - name: 'Download docs PDF'
+        uses: actions/download-artifact@v4
+        with:
+          name: odood-docs-pdf
+          path: build-docs
 
       - name: "Prepare release notes"
         run: csplit --prefix=CHANGELOG. --suffix=%02d.md CHANGELOG.md '/---/'
@@ -120,6 +187,7 @@ jobs:
           files: |
             build-arm64/odood_arm64.deb
             build-amd64/odood_amd64.deb
+            build-docs/output.pdf
           prerelease: true
           body_path: CHANGELOG.00.md
 
@@ -130,5 +198,6 @@ jobs:
           files: |
             build-arm64/odood_arm64.deb
             build-amd64/odood_amd64.deb
+            build-docs/output.pdf
           prerelease: false
           body_path: CHANGELOG.00.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,6 +157,9 @@ jobs:
           name: odood-docs-pdf
           path: build-docs
 
+      - name: Rename docs PDF
+        run: mv build-docs/output.pdf build-docs/odood-documentation.pdf
+
       - name: "Prepare release notes"
         run: csplit --prefix=CHANGELOG. --suffix=%02d.md CHANGELOG.md '/---/'
 
@@ -176,7 +179,7 @@ jobs:
           files: |
             build-arm64/odood_arm64.deb
             build-amd64/odood_amd64.deb
-            build-docs/output.pdf
+            build-docs/odood-documentation.pdf
           prerelease: true
           body_path: CHANGELOG.00.md
 
@@ -187,6 +190,6 @@ jobs:
           files: |
             build-arm64/odood_arm64.deb
             build-amd64/odood_amd64.deb
-            build-docs/output.pdf
+            build-docs/odood-documentation.pdf
           prerelease: false
           body_path: CHANGELOG.00.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,14 +70,14 @@ jobs:
         env:
           BUILD_ODOOD_VERSION: ${{ github.ref_name }}
           BUILD_ODOOD_ARCH: ${{ steps.check-arch.outputs.arch }}
-        run: nfpm package -p deb -t build/odood_${{ github.ref_name }}_${{ steps.check-arch.outputs.arch }}.deb
+        run: nfpm package -p deb -t build/odood_${{ steps.check-arch.outputs.arch }}.deb
 
       - name: Upload Odood compiled assets
         uses: actions/upload-artifact@v4
         with:
           name: odood-${{ steps.check-arch.outputs.arch }}
           path: |
-            build/odood_${{ github.ref_name }}_${{ steps.check-arch.outputs.arch }}.deb
+            build/odood_${{ steps.check-arch.outputs.arch }}.deb
 
   publish_release:
     name: Publish Release
@@ -118,8 +118,8 @@ jobs:
         if: steps.check-rc-release.outputs.is_rc_release == 'true'
         with:
           files: |
-            build-arm64/odood_${{ github.ref_name }}_arm64.deb
-            build-amd64/odood_${{ github.ref_name }}_amd64.deb
+            build-arm64/odood_arm64.deb
+            build-amd64/odood_amd64.deb
           prerelease: true
           body_path: CHANGELOG.00.md
 
@@ -128,7 +128,7 @@ jobs:
         if: steps.check-rc-release.outputs.is_rc_release == 'false'
         with:
           files: |
-            build-arm64/odood_${{ github.ref_name }}_arm64.deb
-            build-amd64/odood_${{ github.ref_name }}_amd64.deb
+            build-arm64/odood_arm64.deb
+            build-amd64/odood_amd64.deb
           prerelease: false
           body_path: CHANGELOG.00.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - ubuntu-22.04-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -27,7 +27,7 @@ jobs:
           echo "arch=$(dpkg --print-architecture)" >> $GITHUB_OUTPUT
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -86,10 +86,10 @@ jobs:
       MDBOOK_VERSION: 0.5.2
       MDBOOK_PDF_VERSION: 0.1.9
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: Cache cargo
         id: cache-cargo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -148,7 +148,7 @@ jobs:
       - build-ubuntu
       - build-docs-pdf
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: 'Download artifacts for amd64'
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,10 +81,10 @@ jobs:
 
   build-docs-pdf:
     name: Build Docs PDF
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       MDBOOK_VERSION: 0.5.2
-      MDBOOK_PDF_VERSION: 0.1.9
+      MDBOOK_PDF_VERSION: 0.1.13
     steps:
       - uses: actions/checkout@v6
 
@@ -113,22 +113,11 @@ jobs:
           # subdirectory: book/html/ for HTML, book/pdf/ for PDF.
           printf '\n[output.pdf]\n' >> docs/odood/book.toml
 
-      - name: Cache cargo
-        id: cache-cargo
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            ~/.cargo/bin/mdbook
-            ~/.cargo/bin/mdbook-pdf
-          key: cargo-mdbook-${{ env.MDBOOK_VERSION }}-pdf-${{ env.MDBOOK_PDF_VERSION }}
-
       - name: Install mdBook and mdbook-pdf
-        if: steps.cache-cargo.outputs.cache-hit != 'true'
         run: |
-          cargo install --version ${MDBOOK_VERSION} mdbook
-          cargo install --version ${MDBOOK_PDF_VERSION} mdbook-pdf
+          wget -qO- "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" | tar -xz -C /usr/local/bin
+          wget -qO /usr/local/bin/mdbook-pdf "https://github.com/HollowMan6/mdbook-pdf/releases/download/v${MDBOOK_PDF_VERSION}/mdbook-pdf-v${MDBOOK_PDF_VERSION}-x86_64-unknown-linux-gnu"
+          chmod +x /usr/local/bin/mdbook-pdf
 
       - name: Build docs
         run: mdbook build ./docs/odood

--- a/.github/workflows/test-deployments.yml
+++ b/.github/workflows/test-deployments.yml
@@ -23,7 +23,7 @@ jobs:
           - ubuntu-22.04-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -31,7 +31,7 @@ jobs:
           echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -94,7 +94,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: 'noninteractive'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -135,7 +135,7 @@ jobs:
           ./build/odood -v -d db drop odood-test-db
 
       - name: Install D compiler (to convert test coverage to cobertura.xml)
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -179,7 +179,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: 'noninteractive'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -237,7 +237,7 @@ jobs:
           ./build/odood -v -d db drop odood-test-db
 
       - name: Install D compiler (to convert test coverage to cobertura.xml)
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 

--- a/.github/workflows/test-os-integrations.yml
+++ b/.github/workflows/test-os-integrations.yml
@@ -20,7 +20,7 @@ jobs:
           - ubuntu-22.04-arm
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -28,7 +28,7 @@ jobs:
           echo "arch=$(uname -m)" >> $GITHUB_OUTPUT
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -75,7 +75,7 @@ jobs:
       DEBIAN_FRONTEND: 'noninteractive'
       ODOOD_PREFER_PY_INSTALL: ${{ matrix.py_install_type }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Check arch
         id: check-arch
@@ -143,7 +143,7 @@ jobs:
         run: ./build/odood-unittest-integration-ut --chrono
 
       - name: Install D compiler (to convert test coverage to cobertura.xml)
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -20,19 +20,20 @@ jobs:
       ODOOD_PREFER_PY_INSTALL: ${{ matrix.py_install_type }}
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ matrix.dc }}
 
       - name: Install system dependencies
         run: |
           brew install libpq
-          brew install postgresql@14
+          brew install postgresql@16
           brew install libzip
           brew install python@3.13
+          echo "$(brew --prefix postgresql@16)/bin" >> $GITHUB_PATH
 
       - name: PyEnv - Install
         if: matrix.py_install_type == 'pyenv'
@@ -49,7 +50,7 @@ jobs:
 
       - name: Start postgresql server
         run: |
-          brew services start postgresql
+          brew services start postgresql@16
           echo 'Check PostgreSQL service is running'
           i=10
           while [ $i -gt 0 ]; do

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ matrix.dc }}
 

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -28,10 +28,10 @@ jobs:
     name: Build Ubuntu:24.04
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install D compiler
-        uses: dlang-community/setup-dlang@v1
+        uses: dlang-community/setup-dlang@v2
         with:
           compiler: ${{ env.ODOOD_DLANG_COMPILER }}
 
@@ -58,7 +58,7 @@ jobs:
     env:
       MDBOOK_VERSION: 0.5.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: 'Download command ref doc'
         uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added `odood server healthcheck` command. One step to make Odood container-friendly.
+- Added `odood server wait-pg` command
+- Added `odood server run --wait-pg` option
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
     - Database manager (`/web/database`) is blocked by default
     - Bugfixes related to nginx config generation
 
+### Fixed
+- Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions
+
 ---
 
 ## Release 0.5.5 (2026-02-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
     - `--ignore-unfinished-updates` - do not fail on unfinished updates
 - Added `--tls12-compat` flag to `odood deploy` to allow TLS 1.2 in addition
   to TLS 1.3 for backward compatibility with older clients.
+- Added `--use-system-ca-bundle` flag to `odood deploy` to set
+  `REQUESTS_CA_BUNDLE` to the system CA certificate store. Auto-detects
+  the CA bundle path across Debian/Ubuntu, RHEL/CentOS/Fedora, and openSUSE.
 
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Commands `odood addons install` and `odood addons update` now will
   fail if there are unfinished addon updates before running command or after.
   This way these commands ensures clean state of db before and after operation.
+- Default dockerimage's command now waits when pg is ready before running Odoo (`odood server run --wait-pg` insteand of `odood server run`)
 
 ### Fixed
 - Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Added new options to `odood addons update`
     - `--installed-only` - install only addons that are not installed in specified db from the list.
     - `--ignore-unfinished-updates` - do not fail on unfinished updates
+- Added `--tls12-compat` flag to `odood deploy` to allow TLS 1.2 in addition
+  to TLS 1.3 for backward compatibility with older clients.
 
 
 ### Changed
@@ -23,6 +25,9 @@
     - Added security headers
     - Database manager (`/web/database`) is blocked by default
     - Bugfixes related to nginx config generation
+- Nginx SSL configuration now defaults to TLS 1.3 only with hardened cipher
+  suites (FIPS 140-2/3 compliant, no CBC/RC4/3DES). Use `--tls12-compat`
+  to enable TLS 1.2 with ECDHE forward secrecy ciphers.
 - Command `odood db list` rewritten in D (no more python / lodoo call)
 - Commands `odood addons install` and `odood addons update` now will
   fail if there are unfinished addon updates before running command or after.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
   fail if there are unfinished addon updates before running command or after.
   This way these commands ensures clean state of db before and after operation.
 - Default dockerimage's command now waits when pg is ready before running Odoo (`odood server run --wait-pg` insteand of `odood server run`)
+- "No access rules" warnings are no longer treated as test errors. Models
+  that intentionally have no ACLs (e.g. sudo()-only technical models) will
+  no longer cause `odood test` to fail.
+
 
 ### Fixed
 - Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added `odood server wait-pg` command
 - Added `odood server run --wait-pg` option
 - Added `odood db is-initialized` command to check if database is already initialized.
+- Added `odood db ensure-initialized` command to  initialize database if it is not initialized yet.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 - Added `odood server healthcheck` command. One step to make Odood container-friendly.
 
+### Changed
+
+- Changed template for `nginx` configuration for `deploy` command:
+    - Added security headers
+    - Database manager (`/web/database`) is blocked by default
+    - Bugfixes related to nginx config generation
+
 ---
 
 ## Release 0.5.5 (2026-02-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
     - Added security headers
     - Database manager (`/web/database`) is blocked by default
     - Bugfixes related to nginx config generation
+- Command `odood db list` rewritten in D (no more python / lodoo call)
 
 ### Fixed
 - Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+---
+
 ## Release 0.5.5 (2026-02-25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+- Added `odood server healthcheck` command. One step to make Odood container-friendly.
+
 ---
 
 ## Release 0.5.5 (2026-02-25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added `odood server healthcheck` command. One step to make Odood container-friendly.
 - Added `odood server wait-pg` command
 - Added `odood server run --wait-pg` option
+- Added `odood db is-initialized` command to check if database is already initialized.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@
 - Added `odood server run --wait-pg` option
 - Added `odood db is-initialized` command to check if database is already initialized.
 - Added `odood db ensure-initialized` command to  initialize database if it is not initialized yet.
+- Added new options to `odood addons install`
+    - `--missing-only` - install only addons that are not installed in specified db from the list.
+    - `--ignore-unfinished-updates` - do not fail on unfinished updates
+- Added new options to `odood addons update`
+    - `--installed-only` - install only addons that are not installed in specified db from the list.
+    - `--ignore-unfinished-updates` - do not fail on unfinished updates
+
 
 ### Changed
 
@@ -17,6 +24,9 @@
     - Database manager (`/web/database`) is blocked by default
     - Bugfixes related to nginx config generation
 - Command `odood db list` rewritten in D (no more python / lodoo call)
+- Commands `odood addons install` and `odood addons update` now will
+  fail if there are unfinished addon updates before running command or after.
+  This way these commands ensures clean state of db before and after operation.
 
 ### Fixed
 - Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions

--- a/README.md
+++ b/README.md
@@ -223,43 +223,50 @@ See examples directory for more details.
 Example `docker-compose.yml`:
 
 ```yml
-version: '3'
-
 volumes:
     odood-example-db-data:
     odood-example-odoo-data:
 
 services:
     odood-example-db:
-        image: postgres:15
+        image: postgres:16
         container_name: odood-example-db
         environment:
-            - POSTGRES_USER=odoo
-            - POSTGRES_PASSWORD=odoo-db-pass
-
-            # this is needed to avoid auto-creation of database by postgres itself
-            # databases must be created by Odoo only
-            - POSTGRES_DB=postgres
+            # Credentials must match ODOOD_OPT_DB_USER / ODOOD_OPT_DB_PASSWORD below.
+            POSTGRES_USER: odoo
+            POSTGRES_PASSWORD: odoo-db-pass
+            # Prevents PostgreSQL from auto-creating a default database;
+            # all Odoo databases must be created by Odoo itself.
+            POSTGRES_DB: postgres
         volumes:
             - odood-example-db-data:/var/lib/postgresql/data
-        restart: "no"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U odoo"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+        restart: unless-stopped
 
     odood-example-odoo:
         image: ghcr.io/katyukha/odood/odoo/18.0:latest
         container_name: odood-example-odoo
         depends_on:
-            - odood-example-db
+            odood-example-db:
+                # Wait until PostgreSQL is healthy before starting Odoo.
+                condition: service_healthy
         environment:
             ODOOD_OPT_DB_HOST: odood-example-db
             ODOOD_OPT_DB_USER: odoo
             ODOOD_OPT_DB_PASSWORD: odoo-db-pass
             ODOOD_OPT_ADMIN_PASSWD: admin
-            ODOOD_OPT_WORKERS: "1"
+            ODOOD_OPT_WORKERS: "2"
+            ODOOD_OPT_PROXY_MODE: "True"
         ports:
             - "8069:8069"
         volumes:
             - odood-example-odoo-data:/opt/odoo/data
-        restart: "no"
+        restart: unless-stopped
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Following features available:
 - Simple installation via prebuilt debian package (see [releases](https://github.com/katyukha/Odood/releases))
 - Support for [assemblies](https://katyukha.github.io/Odood/assembly.html): single repo with all addons for project, populated in semi-automatic way.
 - Build with docker-support in mind
+- Configure Odoo via `ODOOD_OPT_*` environment variables — useful for Docker/K8s deployments
 - Basic integration with [odoo-module-migrator](https://github.com/OCA/odoo-module-migrator). See [docs](https://katyukha.github.io/Odood/addon-migration.html)
 
 
@@ -82,8 +83,16 @@ You can use on of [prebuilt images](https://github.com/katyukha?tab=packages&rep
 
 ## Installation (as Debian Package)
 
-To install Odood, just find debian package in [releases](https://github.com/katyukha/Odood/releases) and install it.
-Thats all.
+To install the latest stable version of Odood, run:
+
+```bash
+wget -O /tmp/odood.deb \
+    "https://github.com/katyukha/Odood/releases/latest/download/odood_$(dpkg --print-architecture).deb"
+sudo apt install -yq /tmp/odood.deb
+```
+
+Or, to install a specific version, visit the [releases](https://github.com/katyukha/Odood/releases) page,
+download the `.deb` package for the desired version and architecture, and install it.
 
 Note, that usually you will need to manually install additional system packages, that include:
 - [postgresql](https://www.postgresql.org/) - if you plan to use local instance of postgresql.
@@ -141,7 +150,7 @@ project with Odood is to run command `odood discover odoo-helper` somewhere insi
 Use following command to create new local (development) odoo instance:
 
 ```bash
-odood init -v 17 -i odoo-17.0 --db-user=odoo17 --db-password=odoo --http-port=17069 --create-db-user
+odood init -v 18 -i odoo-18 --db-user=odoo18 --db-password=odoo --http-port=18069 --create-db-user
 ```
 
 This command will create new virtual environment for Odoo and install odoo there.
@@ -149,13 +158,12 @@ Also, this command will automatically create database user for this Odoo instanc
 
 For production installations, you can use command `odood deploy` that will
 deploy Odoo of specified version to machine where this command is running.
-For example: `odood deploy -v 17 --supervisor=systemd --local-postgres --enable-logrotate`
-But this command is still experimental.
+For example: `odood deploy -v 18 --supervisor=systemd --local-postgres --enable-logrotate`
 
 Next, change current working directory to directory where we installed Odoo:
 
 ```bash
-cd odoo-17.0
+cd odoo-18
 ```
 
 After this, just run command:
@@ -237,7 +245,7 @@ services:
         restart: "no"
 
     odood-example-odoo:
-        image: ghcr.io/katyukha/odood/odoo/17.0:latest
+        image: ghcr.io/katyukha/odood/odoo/18.0:latest
         container_name: odood-example-odoo
         depends_on:
             - odood-example-db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,4 +44,9 @@ EXPOSE 8072
 
 VOLUME ["/opt/odoo/data", "/opt/odoo/backups"]
 
+STOPSIGNAL SIGINT
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD odood server healthcheck -t 9
+
 CMD ["/usr/bin/odood", "--config-from-env", "server", "run"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,4 +49,4 @@ STOPSIGNAL SIGINT
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
     CMD odood server healthcheck -t 9
 
-CMD ["/usr/bin/odood", "--config-from-env", "server", "run"]
+CMD ["/usr/bin/odood", "--config-from-env", "server", "run", "--wait-pg"]

--- a/docs/odood/src/SUMMARY.md
+++ b/docs/odood/src/SUMMARY.md
@@ -5,6 +5,7 @@
 - [Production Deployment](./production-deployment.md)
 - [Assembly](./assembly.md)
 - [Odood Directory Structure](./directory-structure.md)
+- [Development Workflow](./development-workflow.md)
 - [Frequently Used Commands](./frequently-used-commands.md)
 - [Command Reference](./odood-docs-command-ref.md)
 - [odoo-requirements.txt format](./odoo-requirements-txt.md)

--- a/docs/odood/src/SUMMARY.md
+++ b/docs/odood/src/SUMMARY.md
@@ -2,10 +2,22 @@
 
 - [Intro](./intro.md)
 - [Quick Start](./quickstart.md)
-- [Production Deployment](./production-deployment.md)
-- [Assembly](./assembly.md)
-- [Odood Directory Structure](./directory-structure.md)
+
+# Installation
+- [Installing Odood](./installation.md)
+
+# Development
 - [Development Workflow](./development-workflow.md)
+
+# Deployment
+- [Deployment Overview](./deployment.md)
+- [Local Development](./deployment-local.md)
+- [Docker Compose](./deployment-docker-compose.md)
+- [Production (VPS)](./production-deployment.md)
+- [Assembly](./assembly.md)
+
+# Reference
+- [Directory Structure](./directory-structure.md)
 - [Frequently Used Commands](./frequently-used-commands.md)
 - [Command Reference](./odood-docs-command-ref.md)
 - [odoo-requirements.txt format](./odoo-requirements-txt.md)

--- a/docs/odood/src/assembly.md
+++ b/docs/odood/src/assembly.md
@@ -156,6 +156,14 @@ That will do all the job:
 2. relink modules,
 3. update addons on all databases.
 
+#### Docker Compose deployments
+
+When running Odoo in Docker Compose, the assembly is baked into the Docker image at build time
+rather than cloned on the server. Updates therefore follow a different workflow: build a new image,
+stop the running container, run addon updates, restart with the new image.
+
+See [Docker Compose — Upgrading assembly-based deployments](./deployment-docker-compose.md#upgrading-assembly-based-deployments)
+for the full workflow including backup, recovery steps, and the recommended Compose service layout.
 
 ## Assembly management
 
@@ -335,19 +343,226 @@ jobs:
         run: |
           odood --config-from-env -v -d assembly -p . sync \
             --changelog \
+            --dockerfile \
             --commit \
             --commit-user='Github Action' \
             --commit-email='github-action@odood.dev' \
             --push
 ```
 
-This will run assembly build job for all branches starting from `18.0-` prefix.
-Thus, usual flow looks like:
-1. create new branch `18.0-update`
-2. wait while job started
-3. When job completed, create pull request
-4. Review and merge pull request
-5. Delete `18.0-update` branch (or configure to delete stale head branches automatically)
+The `--dockerfile` flag instructs Odood to generate (or regenerate) a `Dockerfile` in the assembly
+repository root on every sync. This Dockerfile copies the synced `dist/` directory into the image
+and runs `odood addons link` — it is what enables building a Docker image from the assembly.
+
+This workflow runs on all branches matching `18.0-*`. Usual flow:
+1. Create a new branch `18.0-update`
+2. Wait for the job to complete
+3. Create a pull request
+4. Review and merge the pull request
+5. Delete the `18.0-update` branch (or configure automatic stale-branch deletion)
+
+#### Semi-automatic update cycle (recommended)
+
+The workflow above commits directly to the current branch.
+For a more controlled flow that requires human review before merging, use a separate
+workflow that creates a PR automatically:
+
+```yaml
+name: Init assembly sync
+on: workflow_dispatch
+
+jobs:
+  init-assembly-sync:
+    name: Init assembly sync
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    container:
+      image: ghcr.io/katyukha/odood/odoo/18.0:latest
+    env:
+      # Credentials for private repos (if needed):
+      # ODOOD_ASSEMBLY_myrepo_CRED: "x-access-token:${{ secrets.MY_REPO_PAT }}"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add current directory as safe directory for git
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Use current repo as assembly
+        run: odood -v -d --config-from-env assembly use .
+
+      - name: Sync assembly
+        run: |
+          odood -v -d --config-from-env assembly sync \
+            --changelog \
+            --commit \
+            --commit-user='Github Action' \
+            --commit-email='github-action@odood.dev' \
+            --push-to=18.0-assembly-update \
+            --fail-nothing-to-commit
+
+  create-pull-request:
+    name: Create assembly sync PR
+    runs-on: ubuntu-latest
+    needs: init-assembly-sync
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - id: check-pr-exists
+        run: |
+          prs=$(gh pr list \
+              --repo "$GITHUB_REPOSITORY" \
+              --head '18.0-assembly-update' \
+              --base '18.0' \
+              --json title \
+              --jq 'length')
+          if ((prs > 0)); then
+              echo "pr_exists=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: '!steps.check-pr-exists.outputs.pr_exists'
+        run: |
+          gh label create auto-update \
+            --repo "$GITHUB_REPOSITORY" \
+            --description "Automatic update" \
+            --force
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --title="Automatic assembly update" \
+            --body="Automatic assembly update" \
+            -l auto-update \
+            -B 18.0 -H 18.0-assembly-update
+```
+
+Key flags used in the sync step:
+- `--push-to=18.0-assembly-update` — pushes to a dedicated update branch instead of the current one.
+- `--fail-nothing-to-commit` — exits non-zero if no addons changed, preventing a no-op PR.
+- `assembly use .` — registers the current directory as the assembly path, needed when the assembly
+  repository and the Odood project share the same repo.
+
+Triggering this workflow creates a draft PR from `18.0-assembly-update` into `18.0` (if one does
+not already exist). Pushing to `18.0-assembly-update` also triggers the `Sync assembly` workflow
+above (it matches `18.0-*`), which re-runs with `--dockerfile` to regenerate the Dockerfile.
+
+#### Releasing a Docker image
+
+Once the update PR is merged to the stable branch, trigger this workflow manually to tag the release
+and build a multi-architecture Docker image published to GHCR:
+
+```yaml
+name: Do Release
+on: workflow_dispatch
+
+jobs:
+  set-tag:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Read version
+        id: version
+        run: echo "version=v$(cat VERSION)" >> $GITHUB_OUTPUT
+      - name: Create version tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.version.outputs.version }}',
+              sha: context.sha
+            }).catch(err => {
+              if (err.status !== 422) throw err;
+              github.rest.git.updateRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: 'tags/${{ steps.version.outputs.version }}',
+                sha: context.sha
+              });
+            })
+
+  build-and-push-docker-image:
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      ODOO_SERIE: '18.0'
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+    runs-on: ubuntu-latest
+    needs: set-tag
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: echo "version=v$(cat VERSION)" >> $GITHUB_OUTPUT
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=match,pattern=v(.*),group=1,value=${{ steps.version.outputs.version }}
+            type=match,pattern=v(\d+\.\d+)\.(.*),group=1,value=${{ steps.version.outputs.version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+```
+
+The `metadata-action` step derives two image tags from the assembly `VERSION` file
+(e.g. `18.0.1.2.3`):
+- **Full version** (`18.0.1.2.3`) — pinned; use this in `docker-compose.yml` for reproducibility and rollback.
+- **Minor version** (`18.0.1.2`) — floating; always points to the latest patch of that minor version.
+
+Multi-arch builds (`linux/amd64,linux/arm64`) require QEMU and Docker Buildx.
+Remove the `platforms` line if you only need `amd64`.
+
+#### Full release cycle
+
+```
+1. Trigger "Init assembly sync" (workflow_dispatch)
+      → syncs addons, commits, pushes to 18.0-assembly-update, opens draft PR
+      → "Sync assembly" fires automatically on the new branch, regenerates Dockerfile
+2. Review and merge the PR to 18.0
+3. Trigger "Do Release" (workflow_dispatch)
+      → reads VERSION file, creates git tag, builds and pushes Docker image with version tags
+4. Deploy using the upgrade workflow:
+      → see Upgrading assembly-based deployments in Docker Compose docs
+```
 
 #### Private repo notes
 

--- a/docs/odood/src/deployment-docker-compose.md
+++ b/docs/odood/src/deployment-docker-compose.md
@@ -263,21 +263,163 @@ docker compose pull
 docker compose up -d
 ```
 
-Odoo will restart with the new image. If the Odoo version has changed, the database upgrade runs automatically on first start.
+Odoo will restart with the new image.
+
+> **Note:** For assembly-based deployments, use the dedicated workflow in
+> [Upgrading assembly-based deployments](#upgrading-assembly-based-deployments) below —
+> it stops Odoo first, runs the addon update step, and covers recovery.
 
 ## Using assembly images
 
-If you manage third-party addons with [Assembly](./assembly.md), build a custom Docker image that includes your assembly on top of the base Odood image:
+When third-party addons are managed with [Assembly](./assembly.md), the assembly's addon directory
+(`dist/`) is baked into a custom Docker image at build time — not cloned or mounted at runtime.
+Every assembly release becomes a distinct, pinned image that can be rolled back if needed.
 
-```dockerfile
-FROM ghcr.io/katyukha/odood/odoo/18.0:latest
+### Building assembly images
 
-# Clone assembly and link addons
-RUN odood assembly init --repo https://github.com/my/assembly \
-    && odood assembly link
+Odood generates the `Dockerfile` automatically. Add `--dockerfile` to the `assembly sync` command
+in your CI workflow and it will be created (or updated) on every sync:
+
+```bash
+odood --config-from-env assembly sync \
+    --changelog \
+    --dockerfile \
+    --commit --push
 ```
 
-See [Assembly](./assembly.md) for details on how to set up and maintain an assembly.
+The generated Dockerfile:
+- Copies `odood-assembly.yml` and `dist/` into `/opt/odoo/assembly/`
+- Runs `odood assembly use /opt/odoo/assembly` to register the assembly in `odood.yml`
+- Runs `odood assembly link` to create symlinks in `custom_addons/`, install Python requirements, and make addons visible to Odoo
+
+Registering the assembly is what makes `--assembly` work in upgrade commands inside the container.
+The image inherits the base image's `CMD`, which already includes `--wait-pg`, so no entrypoint customisation is needed.
+
+See [Assembly CI — Full release cycle](./assembly.md#full-release-cycle) for complete GitHub
+Actions workflows covering sync, PR creation, and image publishing.
+
+### Image tags and docker-compose.yml
+
+The recommended CI workflow publishes two tags per release derived from the assembly `VERSION` file
+(e.g. `18.0.1.2.3`):
+
+- **Full version** (`18.0.1.2.3`) — pinned; use this in `docker-compose.yml`.
+- **Minor version** (`18.0.1.2`) — floating; always points to the latest patch of that minor.
+
+Always pin to the full version tag in `docker-compose.yml` — never `:latest`.
+An explicit tag lets you roll back to the previous image if an upgrade fails.
+Pass the image reference as an environment variable so it can be updated at upgrade time
+without editing the Compose file directly:
+
+```yaml
+services:
+  odoo:
+    image: ${ODOO_IMAGE}   # e.g. ghcr.io/my-org/my-assembly:18.0.1.2.3
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ODOOD_OPT_DB_HOST: db
+      ODOOD_OPT_DB_USER: odoo
+      ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+      ODOOD_OPT_ADMIN_PASSWD: admin
+      ODOOD_OPT_WORKERS: "2"
+      ODOOD_OPT_PROXY_MODE: "True"
+    volumes:
+      - odoo-data:/opt/odoo/data
+    restart: unless-stopped
+```
+
+## Upgrading assembly-based deployments
+
+Running two different versions of addon code against the same database simultaneously risks
+corruption. **Always stop Odoo before running addon updates**, even in containerised environments.
+
+Add the following `odoo-upgrade` service to your `docker-compose.yml`. It shares the image and
+data volume with the main `odoo` service but only runs on demand via the `upgrade` profile:
+
+```yaml
+  odoo-upgrade:
+    image: ${ODOO_IMAGE}
+    profiles: [upgrade]
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ODOOD_OPT_DB_HOST: db        # match your DB service name
+      ODOOD_OPT_DB_USER: odoo
+      ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+    command: >
+      bash -c "
+        odood --config-from-env db backup -a &&
+        odood --config-from-env addons install --missing-only --assembly &&
+        odood --config-from-env addons update --installed-only --assembly
+      "
+    volumes:
+      - odoo-data:/opt/odoo/data
+    restart: "no"
+```
+
+What each command in the upgrade sequence does:
+
+- `db backup -a` — backs up every database before any changes are made.
+- `addons install --missing-only --assembly` — installs assembly addons not yet present in any
+  database (handles newly added modules across releases). Applies to all databases by default.
+- `addons update --installed-only --assembly` — updates only addons that are already installed,
+  skipping uninstalled ones (safe and idempotent). Applies to all databases by default.
+
+`--assembly` works because the generated Dockerfile registers the assembly in `odood.yml`
+via `odood assembly use`, so the container knows where to find the assembly addons.
+
+### Upgrade workflow
+
+```bash
+# Set the new assembly image version (explicit tag — never :latest)
+export ODOO_IMAGE=ghcr.io/my-org/my-assembly:18.0.1.2.3
+
+# 1. Pull the new image
+docker compose pull
+
+# 2. Stop Odoo — the DB container keeps running so the upgrade container can connect
+docker compose stop odoo
+
+# 3. Backup all databases, install new assembly addons, update changed addons
+docker compose --profile upgrade run --rm odoo-upgrade
+
+# 4a. Exit 0 — start Odoo with the new image
+docker compose up -d odoo
+
+# 4b. Non-zero — see Recovery below; Odoo remains stopped until you intervene
+```
+
+### Recovery
+
+If the upgrade fails, restore every database from its pre-upgrade backup and restart Odoo with
+the previous image.
+
+```bash
+# 1. List the backups created before the failed upgrade
+docker compose run --rm --no-deps odoo-upgrade \
+    ls /opt/odoo/data/backups/
+
+# 2. Restore each database from its pre-upgrade backup
+#    Repeat for every database, replacing the name and timestamp
+docker compose run --rm --no-deps odoo-upgrade \
+    odood --config-from-env db restore mydb \
+        /opt/odoo/data/backups/mydb-TIMESTAMP.zip
+
+# 3. Roll back to the previous image and start Odoo
+export ODOO_IMAGE=ghcr.io/my-org/my-assembly:18.0.1.2.2
+docker compose up -d odoo
+```
+
+> **Important:** If `addons update` partially succeeded before the failure (some modules updated,
+> then a crash), the database is in a mixed state — some modules at the new version, others at
+> the old. **Do not attempt to undo partial updates manually.** Restore from the pre-upgrade
+> backup; that is the only clean recovery path.
+
+> **`--no-deps`** starts the upgrade container without attempting to start its declared
+> dependencies — safe to use in recovery when the DB container is already running.
 
 ## Scaling caveat
 

--- a/docs/odood/src/deployment-docker-compose.md
+++ b/docs/odood/src/deployment-docker-compose.md
@@ -1,0 +1,284 @@
+# Docker Compose Deployment
+
+This page covers deploying Odoo with the prebuilt Odood Docker images using Docker Compose.
+
+> **Use with care.**
+> The Docker Compose pattern is well suited for **test environments, CI pipelines, and teams with solid Docker experience**.
+> Docker Compose based installations are not battle-tested in production yet.
+> If you need a stable, low-maintenance production setup, prefer [Production (VPS)](./production-deployment.md) instead.
+
+## When to use
+
+Docker Compose is a reasonable choice when:
+
+- You need a **test or staging environment** that mirrors production without the overhead of bare-metal setup.
+- You are running **CI pipelines** and want a clean, reproducible Odoo stack per run.
+- Your team has **solid Docker and Docker Compose experience** and is comfortable debugging container-level issues.
+- You want configuration managed entirely through **environment variables**.
+
+It is **not** recommended for production unless your team already operates Docker Compose deployments confidently and understands the operational trade-offs.
+It is also **not** the right choice for horizontal scaling — multiple Odoo replicas need shared RWX storage for `/opt/odoo/data`.
+
+For traditional bare-metal or VPS production deployments see [Production (VPS)](./production-deployment.md).
+
+## Prerequisites
+
+- [Docker Engine](https://docs.docker.com/engine/install/) (v20.10+)
+- [Docker Compose v2](https://docs.docker.com/compose/install/) (the `docker compose` plugin, not the legacy `docker-compose` binary)
+
+## Prebuilt images
+
+The official Odood Docker images are published to the GitHub Container Registry:
+
+```
+ghcr.io/katyukha/odood/odoo/{serie}:latest
+```
+
+Available series: `16.0`, `17.0`, `18.0`, `19.0`.
+
+> **Note:** The `--config-from-env` flag and `ODOOD_OPT_*` environment variable support are compiled into these images using the `-d-version OdoodInDocker` build flag.
+> They are **not** available in the Debian package or source builds.
+> See the `ODOOD_OPT_*` reference table in [Development Workflow](./development-workflow.md) for a full list of supported variables.
+
+## HTTP example
+
+The following Compose file runs Odoo 18 with PostgreSQL behind a [Traefik](https://traefik.io/) reverse proxy over plain HTTP.
+It corresponds to the example in [`examples/docker-compose/odoo-and-db/`](https://github.com/katyukha/Odood/tree/main/examples/docker-compose/odoo-and-db).
+
+```yaml
+# Odood Docker Compose Example — HTTP
+#
+# Runs Odoo 18 with PostgreSQL behind a Traefik reverse proxy over plain HTTP.
+#
+# Usage:
+#   docker compose up -d
+#
+# Odoo will be available at http://localhost
+# Traefik dashboard at http://localhost:8080 (disable in production)
+
+volumes:
+    odood-example-db-data:
+    odood-example-odoo-data:
+
+services:
+    odood-example-db:
+        image: postgres:16
+        container_name: odood-example-db
+        environment:
+            # Credentials must match ODOOD_OPT_DB_USER / ODOOD_OPT_DB_PASSWORD below.
+            POSTGRES_USER: odoo
+            POSTGRES_PASSWORD: odoo-db-pass
+            # Prevents PostgreSQL from auto-creating a default database;
+            # all Odoo databases must be created by Odoo itself.
+            POSTGRES_DB: postgres
+        volumes:
+            - odood-example-db-data:/var/lib/postgresql/data
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U odoo"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+        restart: unless-stopped
+
+    odood-example-odoo:
+        image: ghcr.io/katyukha/odood/odoo/18.0:latest
+        container_name: odood-example-odoo
+        labels:
+            # Route all HTTP traffic to Odoo on port 8069.
+            - "traefik.enable=true"
+            - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
+            - "traefik.http.routers.odoo-route.service=odoo-service"
+            - "traefik.http.routers.odoo-route.entrypoints=web"
+            - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
+            # Route /websocket traffic to the Gevent worker on port 8072.
+            - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
+            - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
+            - "traefik.http.routers.odoo-ge-route.entrypoints=web"
+            - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
+        depends_on:
+            odood-example-db:
+                # Wait until PostgreSQL is healthy before starting Odoo.
+                condition: service_healthy
+        environment:
+            # Database connection — must match POSTGRES_USER/PASSWORD above.
+            ODOOD_OPT_DB_HOST: odood-example-db
+            ODOOD_OPT_DB_USER: odoo
+            ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+            # Odoo master password used to create/drop databases via the web UI.
+            ODOOD_OPT_ADMIN_PASSWD: admin
+            # Number of Odoo worker processes. Increase for higher load.
+            # Rule of thumb: (CPU cores * 2) + 1, minimum 2.
+            ODOOD_OPT_WORKERS: "2"
+            # Required when Odoo runs behind a reverse proxy.
+            ODOOD_OPT_PROXY_MODE: "True"
+        volumes:
+            - odood-example-odoo-data:/opt/odoo/data
+        restart: unless-stopped
+
+    odood-example-traefik:
+        image: "traefik:v3.2"
+        container_name: "odood-example-traefik"
+        command:
+            - "--api.insecure=true"
+            - "--providers.docker=true"
+            - "--providers.docker.exposedbydefault=false"
+            - "--entryPoints.web.address=:80"
+        ports:
+            - "80:80"
+            # Traefik dashboard — remove in production.
+            - "8080:8080"
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        restart: unless-stopped
+```
+
+## HTTPS example
+
+The HTTPS example adds TLS termination at the Traefik layer with automatic HTTP→HTTPS redirect.
+It corresponds to [`examples/docker-compose/odoo-and-db-ssl/`](https://github.com/katyukha/Odood/tree/main/examples/docker-compose/odoo-and-db-ssl).
+
+Before starting, place your certificate and key under `./traefik/certs/` and configure `./traefik/traefik-certs.yml` to reference them.
+
+```yaml
+# Odood Docker Compose Example — HTTPS
+#
+# Runs Odoo 18 with PostgreSQL behind Traefik with TLS termination.
+# HTTP (port 80) is automatically redirected to HTTPS (port 443).
+
+volumes:
+    odood-example-ssl-db-data:
+    odood-example-ssl-odoo-data:
+
+services:
+    odood-example-ssl-db:
+        image: postgres:16
+        container_name: odood-example-ssl-db
+        environment:
+            POSTGRES_USER: odoo
+            POSTGRES_PASSWORD: odoo-db-pass
+            POSTGRES_DB: postgres
+        volumes:
+            - odood-example-ssl-db-data:/var/lib/postgresql/data
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U odoo"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+        restart: unless-stopped
+
+    odood-example-ssl-odoo:
+        image: ghcr.io/katyukha/odood/odoo/18.0:latest
+        container_name: odood-example-ssl-odoo
+        labels:
+            - "traefik.enable=true"
+            - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
+            - "traefik.http.routers.odoo-route.service=odoo-service"
+            - "traefik.http.routers.odoo-route.entrypoints=webssl"
+            - "traefik.http.routers.odoo-route.tls=true"
+            - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
+            - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
+            - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
+            - "traefik.http.routers.odoo-ge-route.entrypoints=webssl"
+            - "traefik.http.routers.odoo-ge-route.tls=true"
+            - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
+        depends_on:
+            odood-example-ssl-db:
+                condition: service_healthy
+        environment:
+            ODOOD_OPT_DB_HOST: odood-example-ssl-db
+            ODOOD_OPT_DB_USER: odoo
+            ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+            ODOOD_OPT_ADMIN_PASSWD: admin
+            ODOOD_OPT_WORKERS: "2"
+            ODOOD_OPT_PROXY_MODE: "True"
+        volumes:
+            - odood-example-ssl-odoo-data:/opt/odoo/data
+        restart: unless-stopped
+
+    odood-example-ssl-traefik:
+        image: "traefik:v3.2"
+        container_name: "odood-example-ssl-traefik"
+        command:
+            - "--providers.docker=true"
+            - "--providers.docker.exposedbydefault=false"
+            - "--providers.file.filename=/traefik-certs.yml"
+            - "--entryPoints.web.address=:80"
+            - "--entryPoints.webssl.address=:443"
+            - "--entrypoints.web.http.redirections.entrypoint.to=webssl"
+            - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+        ports:
+            - "80:80"
+            - "443:443"
+        volumes:
+            - "./traefik/traefik-certs.yml:/traefik-certs.yml"
+            - "./traefik/certs/:/certs/"
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        restart: unless-stopped
+```
+
+## Database initialisation
+
+On first start, Odoo's web UI presents a database creation form accessible at `http://localhost` (or `https://localhost` for the SSL example).
+
+Alternatively, initialise a database from the command line:
+
+```bash
+docker compose exec odood-example-odoo \
+    odood --config-from-env db create --demo my-db
+```
+
+To create a database and mark it as initialized (skipping the web setup wizard):
+
+```bash
+docker compose exec odood-example-odoo \
+    odood --config-from-env db ensure-initialized --demo my-db
+```
+
+## Backup and restore
+
+Back up all databases to `/opt/odoo/data/backups/` inside the container:
+
+```bash
+docker compose exec odood-example-odoo \
+    odood --config-from-env db backup -a
+```
+
+The backup files are stored in the `odood-example-odoo-data` volume. Copy them out with `docker cp` or mount a host path to `/opt/odoo/data/backups/`.
+
+Restore a specific database from a backup file:
+
+```bash
+docker compose exec odood-example-odoo \
+    odood --config-from-env db restore my-db /opt/odoo/data/backups/my-db-backup.zip
+```
+
+## Upgrading
+
+Pull the latest images and recreate the containers:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Odoo will restart with the new image. If the Odoo version has changed, the database upgrade runs automatically on first start.
+
+## Using assembly images
+
+If you manage third-party addons with [Assembly](./assembly.md), build a custom Docker image that includes your assembly on top of the base Odood image:
+
+```dockerfile
+FROM ghcr.io/katyukha/odood/odoo/18.0:latest
+
+# Clone assembly and link addons
+RUN odood assembly init --repo https://github.com/my/assembly \
+    && odood assembly link
+```
+
+See [Assembly](./assembly.md) for details on how to set up and maintain an assembly.
+
+## Scaling caveat
+
+Running multiple Odoo replicas requires that `/opt/odoo/data` is stored on shared, RWX-capable storage (e.g. NFS or a cloud file share) so that all replicas can read and write session files and filestore. Without this, session state will be inconsistent across replicas.

--- a/docs/odood/src/deployment-local.md
+++ b/docs/odood/src/deployment-local.md
@@ -1,0 +1,152 @@
+# Local Development
+
+This page covers everything you need to run one or more Odoo instances on a developer machine using `odood init`.
+
+## Prerequisites
+
+The following system packages are required:
+
+- **PostgreSQL** — local database server. Install via your package manager (e.g. `sudo apt install postgresql`).
+- **Python build dependencies** — Odood creates a Python virtualenv for Odoo. Usually the standard `python3`, `python3-dev`, and `python3-venv` packages suffice.
+- **wkhtmltopdf** (optional) — required only if you need to generate PDF reports. Download from the [wkhtmltopdf releases](https://github.com/wkhtmltopdf/packaging/releases) page and install the `.deb` that matches your OS.
+
+## Basic installation
+
+Minimal installation of Odoo 18:
+
+```bash
+odood init -i odoo-18 -v 18
+```
+
+Typical installation with a dedicated database user and HTTP port (recommended when running multiple instances):
+
+```bash
+odood init -i odoo-18 -v 18 --db-user=odoo18 --http-port=18069
+```
+
+After the command completes, Odoo is installed in the `odoo-18` directory. Any subsequent `odood` command run from inside that directory (or any subdirectory) automatically targets that instance.
+
+## Key `odood init` flags
+
+### Version and install type
+
+| Flag | Description |
+|---|---|
+| `-v <series>` | Odoo series to install (`16`, `17`, `18`, `19`, …) |
+| `--install-type=archive` | Install from the official Odoo source archive (default) |
+| `--install-type=git` | Clone from the Odoo git repository (enables `odood venv update-odoo`) |
+
+### Database
+
+| Flag | Description |
+|---|---|
+| `--db-user=<user>` | PostgreSQL role for this instance (default: `odoo`). The role must already exist unless `--create-db-user` is also passed. |
+| `--db-password=<pass>` | Password for the PostgreSQL role (default: `odoo`) |
+| `--db-host=<host>` | PostgreSQL host (default: `localhost`) |
+| `--db-port=<port>` | PostgreSQL port (default: `5432`) |
+| `--create-db-user` | Create the PostgreSQL role automatically. Requires `sudo`. **Not recommended on macOS** — PostgreSQL installation methods on macOS vary and the automatic user creation may not work reliably. |
+
+### HTTP
+
+| Flag | Description |
+|---|---|
+| `--http-port=<port>` | Port Odoo listens on (default: `8069`) |
+| `--longpolling-port=<port>` | Gevent / long-polling port (default: `8072`) |
+
+### Python and Node
+
+| Flag | Description |
+|---|---|
+| `--python=<path>` | Path to the Python executable to use for the virtualenv |
+| `--node-version=<ver>` | Node.js version to install (for frontend assets) |
+| `--pyenv` | Use pyenv to manage the Python version (see macOS section) |
+
+### Advanced
+
+| Flag | Description |
+|---|---|
+| `--repo=<url>` | Git URL of a third-party addon repository to add during init |
+| `--branch=<ref>` | Branch/ref for the `--repo` repository |
+
+Run `odood init --help` to see the full list of options.
+
+## Multiple instances on one machine
+
+Each instance needs a unique combination of:
+- **Installation directory** (`-i`)
+- **HTTP port** (`--http-port`)
+- **Database user** (`--db-user`)
+
+Example: three active development instances:
+
+```bash
+odood init -i odoo-16 -v 16 --db-user=odoo16 --http-port=16069
+odood init -i odoo-17 -v 17 --db-user=odoo17 --http-port=17069
+odood init -i odoo-18 -v 18 --db-user=odoo18 --http-port=18069
+```
+
+Switch between them by changing your working directory:
+
+```bash
+cd ~/odoo-16 && odood server start
+cd ~/odoo-18 && odood server start
+```
+
+## Managing the server
+
+From inside the project directory:
+
+```bash
+odood server start      # start Odoo in the background
+odood server stop       # stop Odoo
+odood server restart    # restart Odoo
+odood server status     # check whether Odoo is running
+odood server log        # view server log (opens in less)
+odood server browse     # open Odoo in the default browser
+odood status            # overall status of this instance
+```
+
+## Adding third-party repositories
+
+```bash
+# Add by full git URL
+odood repo add https://github.com/crnd-inc/generic-addons
+
+# GitHub shortcut
+odood repo add --github crnd-inc/generic-addons
+
+# OCA shortcut (fetches from github.com/OCA/<name>)
+odood repo add --oca web
+```
+
+Odood clones the repository into `repositories/<owner>/<name>/` and symlinks all installable addons into `custom_addons/`, making them visible to Odoo automatically.
+
+## Updating Odoo
+
+To update Odoo to the latest available version, run:
+
+```bash
+odood venv update-odoo
+```
+
+This works for both archive and git-based installations.
+
+## macOS specifics
+
+On macOS the system Python may be incompatible with some Odoo dependencies. Use the `--pyenv` flag to let Odood manage Python via [pyenv](https://github.com/pyenv/pyenv):
+
+```bash
+odood init -i odoo-18 -v 18 --pyenv
+```
+
+Make sure pyenv is installed and initialised in your shell before running the command.
+
+## Migrating from odoo-helper-scripts
+
+If you have existing Odoo instances that were created with [odoo-helper-scripts](https://katyukha.gitlab.io/odoo-helper-scripts/), Odood can import them:
+
+```bash
+odood discover odoo-helper
+```
+
+Run this command from the root of an odoo-helper-scripts project. Odood will detect the existing configuration and create the `odood.yml` file that it needs to manage the instance.

--- a/docs/odood/src/deployment.md
+++ b/docs/odood/src/deployment.md
@@ -1,0 +1,32 @@
+# Deployment Overview
+
+Odood supports three main deployment patterns, each suited to a different operational context.
+Choose the pattern that matches your team size, infrastructure, and operational preferences.
+For all patterns, [Assembly](./assembly.md) is the recommended way to manage third-party addons in production environments.
+
+## Patterns at a glance
+
+| Pattern | Typical use | Key tool |
+|---|---|---|
+| Local development | Developer machine, multiple Odoo versions side by side | `odood init` |
+| Docker Compose | Single-server, small team, easier ops than bare-metal | Prebuilt images + `ODOOD_OPT_*` |
+| VPS / bare-metal | Traditional production, full control, systemd | `odood deploy` |
+
+## How to choose
+
+**Local development** is the fastest way to get Odoo running for day-to-day addon development.
+It installs everything into a single directory, supports multiple isolated instances on one machine (different ports and database users), and requires no special privileges.
+
+**Docker Compose** is a good fit when you want a simple, reproducible deployment on a single server without dealing with systemd, nginx configuration, or Python virtualenv setup.
+The prebuilt Odood images have Odoo pre-installed and can be configured entirely through environment variables.
+It is not ideal for horizontal scaling — multiple replicas require shared RWX storage for Odoo's data directory.
+
+**VPS / bare-metal** gives you full control over the host system: dedicated service accounts, systemd unit files, nginx, logrotate, fail2ban, and Let's Encrypt integration.
+This is the traditional approach for production installations where you manage the server directly.
+
+## Next steps
+
+- [Local Development](./deployment-local.md)
+- [Docker Compose](./deployment-docker-compose.md)
+- [Production (VPS)](./production-deployment.md)
+- [Assembly](./assembly.md)

--- a/docs/odood/src/development-workflow.md
+++ b/docs/odood/src/development-workflow.md
@@ -1,0 +1,425 @@
+# Development Workflow
+
+## Overview
+
+This page describes a recommended workflow for developing Odoo addons in a repository managed alongside Odood.
+It covers local testing (including coverage and warnings), translation management, forward-porting across Odoo series,
+and CI/CD configuration for both GitHub Actions and GitLab CI.
+
+> **Assumption:** This workflow is designed for *multi-addon repositories* — a single git repository containing
+> several related Odoo addons, with one stable branch per supported Odoo series (`17.0`, `18.0`, `19.0`, …).
+> This is the standard layout in the Odoo ecosystem, used by OCA and most independent addon vendors.
+
+## Branching Strategy
+
+The recommended branch naming convention mirrors the Odoo series:
+
+- **Stable branch** — `{serie}` (e.g. `18.0`): production-ready code.
+- **Development branches** — `{serie}-{feature}` (e.g. `18.0-my-feature`): feature or fix branches.
+  CI pipelines are typically triggered on these branches.
+
+## Local Development
+
+### Running Tests
+
+Run tests for a single module on a temporary database:
+
+```bash
+odood test -t <module>
+```
+
+Run tests for all installable addons in the current directory:
+
+```bash
+odood test -t --dir .
+```
+
+Odood creates a temporary database, runs the tests, prints a summary with highlighted errors and warnings, then drops the database.
+
+#### Coverage
+
+Odood uses Python's `coverage` tool (installed in the project virtualenv) to measure test coverage.
+
+```bash
+# Print a terminal coverage summary after tests
+odood test -t --dir . --coverage-report
+
+# Fail if total coverage falls below a threshold (useful in CI)
+odood test -t --dir . --coverage-report --coverage-fail-under 90
+
+# Generate an HTML report in htmlcov/ (open htmlcov/index.html in a browser)
+odood test -t --dir . --coverage-html
+```
+
+`--coverage-report` and `--coverage-html` can be combined in the same command.
+
+#### Warnings report
+
+Odood collects all Odoo log warnings during the test run. To print a deduplicated block of all collected warnings at the end (after the pass/fail summary):
+
+```bash
+odood test -t --dir . --warning-report
+```
+
+This is useful for spotting deprecation notices or misconfigured modules without having to scan the full test log.
+
+### Migration Tests
+
+Migration tests verify that your addons upgrade correctly from the stable branch to the current development branch.
+Odood automates the full cycle: checks out the stable branch, installs modules, optionally populates data, checks out the development branch, and runs the upgrade tests.
+
+Run migration tests for all addons in the current directory:
+
+```bash
+odood test -t --migration --dir .
+```
+
+> **Note:** Migration tests are expected to be a soft failure in CI.
+> They may fail if third-party dependencies introduce changes that are incompatible with the older (stable) version of this repository —
+> a situation outside the developer's control.
+
+### Translation Management
+
+After adding new translatable strings, regenerate translation files with:
+
+```bash
+odood tr regenerate \
+    --pot-remove-dates \
+    --pot \
+    --pot-update \
+    --missing-only \
+    -l uk_UA \
+    --addon-dir .
+```
+
+Key flags:
+- `--pot` — regenerate `.pot` template files.
+- `--pot-update` — update existing `.po` files from the regenerated `.pot`.
+- `--missing-only` — only add new strings; do not overwrite existing translations.
+- `--pot-remove-dates` — strip timestamps from `.pot` headers to reduce noise in git diffs.
+- `-l <lang>` — language code (e.g. `uk_UA`, `de_DE`). Repeat for multiple languages.
+- `--addon-dir <path>` — process all installable addons under the given path.
+
+Commit the resulting `.pot` and `.po` changes alongside your code changes.
+
+### Module Versioning
+
+Odoo addon versions follow the `A.B.X.Y.Z` scheme, where:
+
+- `A.B` — Odoo series (e.g. `18.0`). Set once when the addon or branch is created; never changed manually.
+- `X` — addon major version. Increment for significant data-structure changes that may break backward compatibility.
+- `Y` — addon minor version. Increment for noticeable data-structure changes, or whenever a database migration script is required.
+- `Z` — addon patch version. Increment for low-risk changes (bug fixes, UI tweaks, new fields that don't require migration).
+
+**Rules of thumb:**
+- If you add a migration script → bump at least `Y`.
+- If the migration may break backward compatibility → bump `X`.
+- Everything else → bump `Z`.
+
+Rather than editing `__manifest__.py` files by hand, you can let Odood bump versions automatically:
+
+```bash
+odood repo bump-versions
+```
+
+This inspects the git diff, identifies which modules have changed, and increments their patch version (`Z`).
+Run it inside the repository directory before committing. For minor or major bumps, adjust the version manually afterwards.
+
+Odood also enforces that every changed module has its version bumped via `odood repo check-versions`.
+
+### Version Checks and Pre-commit
+
+Before pushing, verify that all modified modules have their versions bumped:
+
+```bash
+odood repo check-versions --ignore-translations
+```
+
+The `--ignore-translations` flag prevents translation-only commits from triggering a version bump requirement.
+
+To run pre-commit hooks (linters, formatters, etc.) locally:
+
+```bash
+# First-time setup — installs pre-commit and all hooks into the virtualenv:
+odood pre-commit set-up
+
+# Run hooks manually against all staged files:
+odood pre-commit run
+```
+
+### Per-addon Changelog
+
+To track user-facing changes at the module level, each addon can contain a `changelog/` directory.
+Each file inside describes changes introduced in a specific version, using the naming pattern:
+
+```
+changelog/
+└── changelog.X.Y.Z.md
+```
+
+For example, `changelog/changelog.1.3.0.md` contains a markdown description of what changed in version `1.3.0` of that addon.
+
+The file content is free-form markdown — describe what changed from an end-user perspective, not implementation details.
+
+Odood reads these files when generating the assembly-level changelog.
+When you run `odood assembly sync --changelog`, it aggregates per-addon changelogs across all updated modules into a single `CHANGELOG.md` (and `CHANGELOG.latest.md`) at the assembly root — useful for release notes and communicating changes to end users.
+
+---
+
+## Forward-porting
+
+When you maintain addons across multiple Odoo series (e.g. 17.0 and 18.0), development typically happens on the oldest supported series first, and the resulting changes are then forward-ported to newer series.
+
+For example, you develop a fix on `17.0`, then need to carry it into `18.0` and `19.0`.
+The naive approach — manually cherry-picking or re-applying changes — is tedious because:
+
+- Module versions embed the series prefix and must be updated (e.g. `17.0.1.2.3` → `18.0.1.2.3`).
+- Migration script directories also embed the series (e.g. `migrations/17.0.1.2.3/` → `migrations/18.0.1.2.3/`).
+- Translation files in the target branch should be kept as-is — conflicts in `.po`/`.pot` files are meaningless and always resolved in favour of the target branch.
+
+`odood repo do-forward-port` automates all of this, leaving only genuine business-logic conflicts for you to resolve manually.
+
+### Workflow
+
+1. Switch to your Odoo environment for the **target** series (e.g. your `18.0` project).
+2. Change into the repository directory.
+3. Create (or check out) a forward-port branch:
+   ```bash
+   git checkout -b 18.0-forward-port-<feature>
+   ```
+4. Run the forward-port command, naming the **source** series:
+   ```bash
+   odood repo do-forward-port -s 17.0
+   ```
+   The command will automatically:
+   - Fetch `origin/17.0` and open a merge (`--no-ff --no-commit`) into the current branch, staging all changes for review.
+   - Reset `.po`/`.pot` files to the target-branch version — translation conflicts are always discarded.
+   - Fix version number conflicts in each addon's `__manifest__.py`, rewriting the series prefix.
+   - Rename migration script directories from the source series to the target series (e.g. `migrations/17.0.1.2.3/` → `migrations/18.0.1.2.3/`).
+
+5. Resolve any remaining merge conflicts (business logic, structural changes, etc.).
+6. Run tests to verify everything works in the target series:
+   ```bash
+   odood test -t --dir .
+   ```
+7. Commit and push:
+   ```bash
+   git push origin 18.0-forward-port-<feature>
+   ```
+8. Open a pull/merge request into the `18.0` stable branch and wait for CI to pass.
+9. Repeat steps 1–8 for each remaining target series (`19.0`, etc.).
+
+> **Note:** `do-forward-port` is currently marked experimental.
+> In straightforward cases (no structural conflicts) it produces a ready-to-commit merge with zero manual intervention.
+
+---
+
+## CI/CD Configuration
+
+### Key concept: `--config-from-env` and `ODOOD_OPT_*`
+
+The prebuilt Docker images (`ghcr.io/katyukha/odood/odoo/{serie}:latest`) already have Odoo installed and ready.
+`ODOOD_OPT_*` environment variables allow you to override individual Odoo configuration options (i.e. values in `odoo.conf`) at runtime — without modifying any file on disk.
+Combined with the `--config-from-env` flag, this is the standard way to point CI containers at the PostgreSQL sidecar.
+
+For example, set these environment variables in your CI job:
+
+```
+ODOOD_OPT_DB_HOST=postgres
+ODOOD_OPT_DB_USER=odoo
+ODOOD_OPT_DB_PASSWORD=odoo
+```
+
+Then invoke Odood as:
+
+```bash
+odood --config-from-env addons link .
+odood --config-from-env test -t --dir .
+```
+
+---
+
+### GitHub Actions
+
+The following workflow runs on development branches (`18.0-*`).
+It has three jobs: **lint** (runs first), then **tests** and **migration-tests** in parallel.
+
+```yaml
+name: Tests
+on:
+  push:
+    branches:
+      - '18.0-*'
+
+jobs:
+  lint:
+    name: Lint & version checks
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/katyukha/odood/odoo/18.0:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add repo as git safe directory
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Link addons
+        run: odood --config-from-env addons link .
+
+      - name: Add dependencies
+        run: odood --config-from-env addons add --single-branch --odoo-requirements ./odoo_requirements.txt
+
+      - name: Check versions
+        run: odood --config-from-env repo check-versions --ignore-translations
+
+      - name: Install pre-commit
+        run: odood --config-from-env pre-commit set-up
+
+      - name: Run pre-commit
+        run: odood --config-from-env pre-commit run
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    container:
+      image: ghcr.io/katyukha/odood/odoo/18.0:latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ODOOD_OPT_DB_HOST: postgres
+      ODOOD_OPT_DB_USER: odoo
+      ODOOD_OPT_DB_PASSWORD: odoo
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add repo as git safe directory
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Link addons
+        run: odood --config-from-env addons link .
+
+      - name: Add dependencies
+        run: odood --config-from-env addons add --single-branch --odoo-requirements ./odoo_requirements.txt
+
+      - name: Run tests
+        run: odood --config-from-env test -t --dir .
+
+  migration-tests:
+    name: Migration Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    # Migration tests may fail if dependencies introduce incompatible changes
+    # with an older version of this repo — treated as a soft failure.
+    continue-on-error: true
+    container:
+      image: ghcr.io/katyukha/odood/odoo/18.0:latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: odoo
+          POSTGRES_PASSWORD: odoo
+          POSTGRES_DB: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      ODOOD_OPT_DB_HOST: postgres
+      ODOOD_OPT_DB_USER: odoo
+      ODOOD_OPT_DB_PASSWORD: odoo
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Add repo as git safe directory
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Link addons
+        run: odood --config-from-env addons link .
+
+      - name: Add dependencies
+        run: odood --config-from-env addons add --single-branch --odoo-requirements ./odoo_requirements.txt
+
+      - name: Run migration tests
+        run: odood --config-from-env test -t --migration --dir .
+```
+
+> **Tip:** If your addons have no third-party dependencies, you can omit the "Add dependencies" step and the `odoo_requirements.txt` file.
+
+---
+
+### GitLab CI
+
+The following pipeline mirrors the GitHub Actions structure using GitLab CI's `extends` keyword to share the common setup.
+
+```yaml
+image: ghcr.io/katyukha/odood/odoo/18.0:latest
+
+stages:
+  - lint
+  - test
+
+# Shared setup: link addons and fetch dependencies.
+# Requires odoo_requirements.txt at repo root; remove the second line if not needed.
+.setup:
+  before_script:
+    - git config --global --add safe.directory "$(pwd)"
+    - odood --config-from-env addons link .
+    - odood --config-from-env addons add --single-branch --odoo-requirements ./odoo_requirements.txt
+
+# Shared PostgreSQL sidecar and matching ODOOD_OPT_* variables.
+.with-postgres:
+  services:
+    - name: postgres:15
+      alias: postgres
+  variables:
+    POSTGRES_USER: odoo
+    POSTGRES_PASSWORD: odoo
+    POSTGRES_DB: postgres
+    ODOOD_OPT_DB_HOST: postgres
+    ODOOD_OPT_DB_USER: odoo
+    ODOOD_OPT_DB_PASSWORD: odoo
+
+lint:
+  extends: .setup
+  stage: lint
+  script:
+    - odood --config-from-env repo check-versions --ignore-translations
+    - odood --config-from-env pre-commit set-up
+    - odood --config-from-env pre-commit run
+
+tests:
+  extends:
+    - .setup
+    - .with-postgres
+  stage: test
+  script:
+    - odood --config-from-env test -t --dir .
+
+migration-tests:
+  extends:
+    - .setup
+    - .with-postgres
+  stage: test
+  only:
+    - /^18\.0-.*$/
+  script:
+    # Migration tests may fail if dependencies introduce incompatible changes
+    # with an older version of this repo — treated as a soft failure.
+    - odood --config-from-env test -t --migration --dir .
+  allow_failure: true
+```
+
+> **Note:** Adjust the Odoo series (`18.0`) in the image tag and the `only` regex to match your project's series.

--- a/docs/odood/src/development-workflow.md
+++ b/docs/odood/src/development-workflow.md
@@ -222,6 +222,10 @@ The prebuilt Docker images (`ghcr.io/katyukha/odood/odoo/{serie}:latest`) alread
 `ODOOD_OPT_*` environment variables allow you to override individual Odoo configuration options (i.e. values in `odoo.conf`) at runtime — without modifying any file on disk.
 Combined with the `--config-from-env` flag, this is the standard way to point CI containers at the PostgreSQL sidecar.
 
+> **Note:** The `--config-from-env` flag and `ODOOD_OPT_*` support are only compiled in when Odood is built
+> with the `-d-version OdoodInDocker` flag, and thus are available only in the official prebuilt Docker images.
+> The Debian package and source builds do not include this flag.
+
 For example, set these environment variables in your CI job:
 
 ```
@@ -236,6 +240,29 @@ Then invoke Odood as:
 odood --config-from-env addons link .
 odood --config-from-env test -t --dir .
 ```
+
+#### Common `ODOOD_OPT_*` variables
+
+Each variable maps directly to the corresponding key in Odoo's `[options]` section of `odoo.conf`.
+The prefix `ODOOD_OPT_` is stripped and the remainder is lowercased before being applied.
+
+| Environment variable | `odoo.conf` key | Description |
+|---|---|---|
+| `ODOOD_OPT_DB_HOST` | `db_host` | PostgreSQL host |
+| `ODOOD_OPT_DB_PORT` | `db_port` | PostgreSQL port (default: `5432`) |
+| `ODOOD_OPT_DB_USER` | `db_user` | PostgreSQL user |
+| `ODOOD_OPT_DB_PASSWORD` | `db_password` | PostgreSQL password |
+| `ODOOD_OPT_ADMIN_PASSWD` | `admin_passwd` | Odoo master password (database manager) |
+| `ODOOD_OPT_WORKERS` | `workers` | Number of worker processes (`0` = single-process mode) |
+| `ODOOD_OPT_PROXY_MODE` | `proxy_mode` | Set `True` when running behind a reverse proxy |
+| `ODOOD_OPT_DBFILTER` | `dbfilter` | Regex to restrict which databases are served |
+| `ODOOD_OPT_LIMIT_MEMORY_HARD` | `limit_memory_hard` | Hard memory limit per worker (bytes) |
+| `ODOOD_OPT_LIMIT_MEMORY_SOFT` | `limit_memory_soft` | Soft memory limit per worker (bytes) |
+| `ODOOD_OPT_LIMIT_TIME_CPU` | `limit_time_cpu` | CPU time limit per request (seconds) |
+| `ODOOD_OPT_LIMIT_TIME_REAL` | `limit_time_real` | Real time limit per request (seconds) |
+| `ODOOD_OPT_LOG_LEVEL` | `log_level` | Log level (`info`, `debug`, `warning`, `error`) |
+
+Any other valid `odoo.conf` option can be set the same way — the list above covers the most commonly needed ones in containerised deployments.
 
 ---
 

--- a/docs/odood/src/development-workflow.md
+++ b/docs/odood/src/development-workflow.md
@@ -264,6 +264,8 @@ The prefix `ODOOD_OPT_` is stripped and the remainder is lowercased before being
 
 Any other valid `odoo.conf` option can be set the same way — the list above covers the most commonly needed ones in containerised deployments.
 
+For deployment context (not CI), see [Docker Compose deployment](./deployment-docker-compose.md).
+
 ---
 
 ### GitHub Actions

--- a/docs/odood/src/frequently-used-commands.md
+++ b/docs/odood/src/frequently-used-commands.md
@@ -9,28 +9,29 @@ just call if with `-h` option.
 ### Server management
 - `odood start` - start odoo server
 - `odood restart` - restart odoo server
-- `odood stop` - stop odoo-helper server
+- `odood stop` - stop odoo server
 - `odood log` - see odoo server logs
 - `odood browse` - open running odoo installation in browser
 
 ### Addons management
 - `odood addons list <path>` - list odoo addons in specified directory
 - `odood addons update-list` - update list of available addons in all databases available for this server
-- `odood addons install <addon1> [addonN]` - install specified odoo addons for all databases available for this server
-- `odood addons update <addon1> [addonN]` - update specified odoo addons for all databases available for this server
+- `odood addons install <addon1> [addonN]` - install specified odoo addons for all databases available for this server; use `--missing-only` to skip already-installed ones
+- `odood addons update <addon1> [addonN]` - update specified odoo addons for all databases available for this server; use `--installed-only` to skip non-installed ones
 - `odood addons uninstall <addon1> [addonN]` - uninstall specified odoo addons for all databases available for this server
 - `odood addons update --dir <path>` - find all installable addons in specified directory and update them
 - `odood addons install --dir <path>` - find all installable addons in specified directory and install them
 - `odood addons link .` - link all addons in current directory.
 - `odood addons add -h` - add third-party addons from [odoo-apps](https://apps.odoo.com/apps) (free only) or from [odoo-requirements.txt](./odoo-requirements-txt.md)
 
+Both `install` and `update` support `--ignore-unfinished-updates` to proceed even if the database has pending addon state transitions.
+
 ### Tests
-- `odoo-helper test -t <module>` - test single module on temporary database
-- `odoo-helper test -t --dir .` - test all installable addons in current directory
-- `odoo-helper test -t --migration --dir .` - run migration test for all installable addons in current directory.
-  This includes switching to stable branch, installing modules, optionally populating with extra data, switching back to test branch and running tests for migrated addons.
-- `odoo-helper test --coverage-html <module>` - test single module and create html coverage report in current dir
-- `odoo-helper test --coverage-html --dir .` - test all installable addons in current directory and create html coverage report in current dir
+- `odood test -t <module>` - test single module on temporary database
+- `odood test -t --dir .` - test all installable addons in current directory
+- `odood test -t --migration --dir .` - run migration tests for all installable addons in current directory
+- `odood test --coverage-html -t <module>` - test single module and create html coverage report
+- `odood test --coverage-html --dir .` - test all installable addons and create html coverage report
 
 ### Pre-commit
 

--- a/docs/odood/src/production-deployment.md
+++ b/docs/odood/src/production-deployment.md
@@ -70,7 +70,7 @@ This sample, assumes, that you have control over your domain, and already point 
 **Note**, you have to update command below with your correct architecture.
 
 So,
-Let 's run following commands to get complete production ready Odoo installation on **Ubuntu 24.04** on **amd64** architecture:
+Let 's run following commands to get complete production ready Odoo installation on **Ubuntu 24.04**:
 
 ```bash
 sudo apt-get update -yq    # update list of packages
@@ -80,7 +80,8 @@ sudo apt-get upgrade -yq   # upgrade packages
 sudo apt-get install -yq wget nginx postgresql certbot fail2ban
 
 # Download and install latest version of Odood
-wget -O /tmp/odood.deb https://github.com/katyukha/Odood/releases/download/v0.5.4/odood_v0.5.4_amd64.deb
+wget -O /tmp/odood.deb \
+    "https://github.com/katyukha/Odood/releases/latest/download/odood_$(dpkg --print-architecture).deb"
 sudo apt install -yq /tmp/odood.deb
 
 # Download and install correct version of Wkhtmltopdf
@@ -106,10 +107,8 @@ Following list of commands will install Odoo with configured nginx, postgresql, 
 
 This sample, assumes, that you have already generate self-signed certificates.
 
-**Note**, you have to update command below with your correct architecture.
-
 So,
-Let 's run following commands to get complete  production ready Odoo installation on **Ubuntu 24.04** on **amd64** architecture:
+Let 's run following commands to get complete production ready Odoo installation on **Ubuntu 24.04**:
 
 ```bash
 sudo apt-get update -yq    # update list of packages
@@ -119,7 +118,8 @@ sudo apt-get upgrade -yq   # upgrade packages
 sudo apt-get install -yq wget nginx postgresql certbot fail2ban
 
 # Download and install latest version of Odood
-wget -O /tmp/odood.deb https://github.com/katyukha/Odood/releases/download/v0.5.4/odood_v0.5.4_amd64.deb
+wget -O /tmp/odood.deb \
+    "https://github.com/katyukha/Odood/releases/latest/download/odood_$(dpkg --print-architecture).deb"
 sudo apt install -yq /tmp/odood.deb
 
 # Download and install correct version of Wkhtmltopdf

--- a/docs/odood/src/quickstart.md
+++ b/docs/odood/src/quickstart.md
@@ -8,7 +8,7 @@ if you are interested what it can do, just type `odood --help` :)
 
 ## Installation
 
-To install the latest stable version of Odood, run:
+To install the latest stable version of Odood on Debian/Ubuntu, run:
 
 ```bash
 wget -O /tmp/odood.deb \
@@ -16,226 +16,110 @@ wget -O /tmp/odood.deb \
 sudo apt install -yq /tmp/odood.deb
 ```
 
-Or, to install a specific version, visit the [releases](https://github.com/katyukha/Odood/releases) page,
-download the `.deb` package for the desired version and architecture, and install it.
-
-Usually you will need to manually install additional system packages, that include:
-- [postgresql](https://www.postgresql.org/) - if you plan to use local instance of postgresql.
-- [wkhtmltopdf](https://github.com/wkhtmltopdf/packaging/releases) - Required to generate pdf reports. See [Odoo docs](https://github.com/odoo/odoo/wiki/Wkhtmltopdf) for more info.
+For macOS, specific versions, and system dependency details, see [Installing Odood](./installation.md).
 
 ## Odoo installation
 
-There are two types of Odoo installation supported by Odood:
-- Development
-- Production
-
-### Development installation
-
-Development installation is designed to be super easy for developer.
-Thus it just installs Odoo and everything needed into specified directory.
-No specific user for Odoo process, no access restrictions, etc.
-Instead, it is designed to be able to work with multiple Odoo instances
-installed on same system.
-
-To install Odoo 18 for development, following command could be used:
-
-```bash
-odood init -i odoo-18 -v 18
-```
-
-But, usually it is used with other options, to use separate database user and separate port for each development Odoo instance.
-For example:
+To install Odoo 18 for local development:
 
 ```bash
 odood init -i odoo-18 -v 18 --db-user=odoo18 --http-port=18069
 ```
 
-After this command, Odoo 18 will be installed in `odoo-18` directory.
-Next, if current working directory is inside `odoo-18`, then `odood` command could be used to manage this instance.
+This installs Odoo 18 into the `odoo-18` directory, using a dedicated database user and HTTP port.
+For more options and multi-instance setups, see [Local Development](./deployment-local.md).
 
-### Production installation
-
-Production installation more focuses on security, and stabiltiy.
-Thus, it do following additional tasks:
-- Creates separate user to run Odoo
-- Creates systemd service or init script to run Odoo at startup
-- Optionally configures:
-  - logrotate
-  - nginx
-  - fail2ban
-
-For more info take a look at [Production Deployment](./production-deployment.md) article.
+For Docker Compose or VPS/bare-metal deployments, see the [Deployment Overview](./deployment.md).
 
 ## Server management
 
-After installation following commands available to manage Odoo server:
-- `odood server start` - start Odoo in background
-- `odood server stop` - stop Odoo if running 
-- `odood server restart` - restart Odoo
-- `odood server browse` - open Odoo in your browser
-- `odood server run` - run odoo itself.
-- `odood server log` - view server logs (automatically use `less` utility to view Odoo server log)
-- `odood server status` - Check if Odoo server is running or not
-- `odood status` - status of this Odoo instance.
+After installation the following commands are available from inside the project directory:
+
+```bash
+odood server start    # start Odoo in the background
+odood server stop     # stop Odoo
+odood server restart  # restart Odoo
+odood server browse   # open Odoo in your browser
+odood server log      # view server logs
+odood server status   # check if Odoo is running
+odood status          # status of this Odoo instance
+```
 
 ## Database management
 
-Now we can create new Odoo database inside installed Odoo instance.
-
-To do this we can use following command:
+Create a test database (name generated automatically):
 
 ```bash
 odood db create --demo --tdb --recreate
 ```
 
-This command will create new test Odoo database on this Odoo instance.
-The name for test odoo database is generated automatically as `<dbuser>-odood-test`.
-Such test database is useful during development stage: you do not need to thing about name of database
-during frequent database creation/recreation.
-
-Or, we can create demo database with specific name
+Or create a database with a specific name:
 
 ```bash
 odood db create --demo --recreate my-demo-db
 ```
 
-Next we can view list of databases:
+List databases:
 
 ```bash
 odood db list
-```
-
-Also, there is shortcut for this frequently used command:
-
-```bash
+# shortcut:
 odood lsd
 ```
 
-Additionally following commands may be useful:
-- `odood db drop`
-- `odood db copy`
-- `odood db backup`
-- `odood db restore`
-- `odood db rename`
-- `odood db stun` - disable cron jobs and mail servers
-- `odood db list-installed-addons` - show list of addons installed in specific DB
-
 ## Addons management
 
-One of the frequent usecases of Odood is management of third-party modules (or own addons).
+### Install a third-party addon
 
-### Install third-party addon
-Let's install for example module `generic_location` from [generic-addons](https://github.com/crnd-inc/generic-addons) repository.
-
-To do this, we can use following command:
+Add the repository containing the addon, then install it:
 
 ```bash
+# Add repository (full URL or GitHub shortcut)
 odood repo add https://github.com/crnd-inc/generic-addons
-```
-
-Or we can use shortcut:
-
-```bash
+# or:
 odood repo add --github crnd-inc/generic-addons
 ```
 
-This command will fetch specified git repository, and store it at `repositories/crnd-inc/generic-addons` directory in project root,
-and all addons in that repo will be automatically symlinked to `custom_addons` directory inside project root,
-thus they will become visible for Odoo.
+Odood clones the repository into `repositories/crnd-inc/generic-addons/` and symlinks all addons to `custom_addons/`, making them visible to Odoo.
 
-Next, we could use following command to install module `generic_location` into created database:
+Install a specific module into a database:
 
 ```bash
 odood addons install -d my-demo-db generic_location
 ```
 
-After this command, module `generic_location` will be installed in database `my-demo-db`
-
 ### Update third-party modules
 
-One of the most frequent tasks related to management of Odoo servers is update of third party modules.
-In our case, we have repository `generic-addons`, and we may need to update modules from this repo.
-To do this, we have to use following algorithm:
-0. Take backup (use `odood db backup -a` for this)
-1. Pull changes from repo (use `git pull` for this)
-2. Stop Odoo server
-3. Install / update all required dependencies
-4. Run update for all modules from this repo for all databases.
-5. Start Odoo server again
-
-Using Odood for our example, it could be done in following way:
+One of the most frequent tasks is updating third-party modules.
+The typical workflow:
 
 ```bash
-#  Change current working directory to repository that we want to update
+# Change to the repository directory
 cd repositories/crnd-inc/generic-addons
 
-# Pull changes for the repository
+# Pull latest changes
 git pull
 
-# We have to relink addons in case when new addons were added
-# or new python dependencies were added.
-# With this command Odood will handle most of this cases automatically
+# Relink addons (handles new addons and new Python dependencies)
 odood addons link .
 
-# Update all modules inside current directory for all databases
-# Also, automatically update list of addons in each database.
-# This command will automatically stop Odoo before update if needed
-# and start again after update.
+# Update all modules in this directory for all databases
+# (stops Odoo automatically before update, starts again after)
 odood addons update -a --ual --dir .
 ```
 
-### Addons management commands
-
-- `add` - Add addons to the project
-- `update-list` -Update list of addons.
-- `link` - Link addons in specified directory.
-- `generate-py-requirements`  - Generate python's requirements.txt from addon's manifests. By default, it prints requirements to stdout.
-- `update` - Update specified addons. Use `--installed-only` to skip addons that are not yet installed.
-- `install` - Install specified addons. Use `--missing-only` to skip addons that are already installed.
-- `is-installed` - Print list of databases wehre specified addon is installed.
-- `uninstall` - Uninstall specified addons.
-- `list` - List addons in specified directory.
-- `find-installed` - Find addons installed on specified database(s).
-
-Both `install` and `update` support `--ignore-unfinished-updates` to proceed even if the database has pending addon state transitions.
-
 ## Running tests
 
-During development, it is frequent case to run automated tests for modules being developed.
-So, Odood provides separate command `odood test` that runs tests for specified modules.
-
-It is recommended to look at `--help` for this command (`odood test -h`) to get more info about what it can do.
-
-In our case, let's run tests for module `generic_location`. to do this, we can run following command:
+Run tests for a single module on a temporary database:
 
 ```bash
 odood test -t generic_location
 ```
 
-This command will create temporary database to run tests in, automatically find module `generic_location` and run tests for it with colored highlights for errors and warnings.
-
-Also, it is possible to run test for whole repo.
-Assume, we are inside `repositories/crnd-inc/generic-addons`, then we can just run command:
+Run tests for all installable addons in the current repository directory:
 
 ```bash
 odood test -t --dir .
 ```
 
-It will automatically find all addons in this repo, and run tests for all of them on same temporary database.
-
-## Virtualenv managment
-
-Additionally, sometimes it is useful to manage virtualenv of Odood project.
-For this reason, Odood has `ododo venv` subcommand, that contains various commands to manage virtual environment of this project:
-
-- `install-dev-tools` - Install Dev Tools
-- `run` - Run command in this virtual environment. The command and all arguments must be specified after '--'. For example: 'odood venv run -- ipython'
-- `reinstall-odoo` - Reinstall Odoo to different Odoo version.
-- `npm` - Run npm for this environment. All arguments after '--' will be forwarded directly to npm.
-- `ipython` - Run ipython in this environment. All arguments after '--' will be forwarded directly to python.
-- `python` - Run python for this environment. All arguments after '--' will be forwarded directly to python.
-- `update-odoo` - Update Odoo itself.
-- `pip` - Run pip for this environment. All arguments after '--' will be forwarded directly to pip.
-- `reinstall` - Reinstall virtualenv.
-- `install-py-packages` - Install Python packages
-
+Odood creates a temporary database, runs the tests with coloured error/warning highlights, then drops the database.

--- a/docs/odood/src/quickstart.md
+++ b/docs/odood/src/quickstart.md
@@ -8,10 +8,16 @@ if you are interested what it can do, just type `odood --help` :)
 
 ## Installation
 
-In order to install Odood, you have to do following:
-1. Visit [releases](https://github.com/katyukha/Odood/releases) page
-2. Download `.deb` package for desired architecture
-3. Install downloaded `.deb` package.
+To install the latest stable version of Odood, run:
+
+```bash
+wget -O /tmp/odood.deb \
+    "https://github.com/katyukha/Odood/releases/latest/download/odood_$(dpkg --print-architecture).deb"
+sudo apt install -yq /tmp/odood.deb
+```
+
+Or, to install a specific version, visit the [releases](https://github.com/katyukha/Odood/releases) page,
+download the `.deb` package for the desired version and architecture, and install it.
 
 Usually you will need to manually install additional system packages, that include:
 - [postgresql](https://www.postgresql.org/) - if you plan to use local instance of postgresql.

--- a/docs/odood/src/quickstart.md
+++ b/docs/odood/src/quickstart.md
@@ -190,12 +190,14 @@ odood addons update -a --ual --dir .
 - `update-list` -Update list of addons.
 - `link` - Link addons in specified directory.
 - `generate-py-requirements`  - Generate python's requirements.txt from addon's manifests. By default, it prints requirements to stdout.
-- `update` - Update specified addons.
-- `install` - Install specified addons.
+- `update` - Update specified addons. Use `--installed-only` to skip addons that are not yet installed.
+- `install` - Install specified addons. Use `--missing-only` to skip addons that are already installed.
 - `is-installed` - Print list of databases wehre specified addon is installed.
 - `uninstall` - Uninstall specified addons.
 - `list` - List addons in specified directory.
 - `find-installed` - Find addons installed on specified database(s).
+
+Both `install` and `update` support `--ignore-unfinished-updates` to proceed even if the database has pending addon state transitions.
 
 ## Running tests
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -7,7 +7,7 @@
 		"cachetools": "0.4.2",
 		"colored": "0.0.31",
 		"commandr": "1.1.0",
-		"darktemple": "0.0.8",
+		"darktemple": "0.0.9",
 		"dini": "2.0.0",
 		"dpq": "0.11.6",
 		"dshould": "1.8.0",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -20,7 +20,7 @@
 		"tabletool": "0.5.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.1.0",
+		"theprocess": "0.1.1",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.1.9",
 		"versioned": "0.1.0",

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -20,7 +20,7 @@
 		"tabletool": "0.5.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.0.10",
+		"theprocess": "0.1.0",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.1.9",
 		"versioned": "0.1.0",

--- a/examples/docker-compose/odoo-and-db-ssl/docker-compose.yml
+++ b/examples/docker-compose/odoo-and-db-ssl/docker-compose.yml
@@ -1,4 +1,16 @@
-version: '3'
+# Odood Docker Compose Example — HTTPS
+#
+# Runs Odoo 18 with PostgreSQL behind a Traefik reverse proxy with TLS termination.
+# HTTP (port 80) is automatically redirected to HTTPS (port 443).
+#
+# Prerequisites:
+#   Place your TLS certificate and key under ./traefik/certs/ and reference them
+#   in ./traefik/traefik-certs.yml.
+#
+# Usage:
+#   docker compose up -d
+#
+# Odoo will be available at https://localhost
 
 volumes:
     odood-example-ssl-db-data:
@@ -6,68 +18,81 @@ volumes:
 
 services:
     odood-example-ssl-db:
-        image: postgres:15
+        image: postgres:16
         container_name: odood-example-ssl-db
         environment:
-            - POSTGRES_USER=odoo
-            - POSTGRES_PASSWORD=odoo-db-pass
-
-            # this is needed to avoid auto-creation of database by postgres itself
-            # databases must be created by Odoo only
-            - POSTGRES_DB=postgres
+            # Credentials must match ODOOD_OPT_DB_USER / ODOOD_OPT_DB_PASSWORD below.
+            POSTGRES_USER: odoo
+            POSTGRES_PASSWORD: odoo-db-pass
+            # Prevents PostgreSQL from auto-creating a default database;
+            # all Odoo databases must be created by Odoo itself.
+            POSTGRES_DB: postgres
         volumes:
             - odood-example-ssl-db-data:/var/lib/postgresql/data
-        restart: "no"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U odoo"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+        restart: unless-stopped
 
     odood-example-ssl-odoo:
-        image: ghcr.io/katyukha/odood/odoo/17.0:latest
+        image: ghcr.io/katyukha/odood/odoo/18.0:latest
         container_name: odood-example-ssl-odoo
         labels:
-          - "traefik.enable=true"
-          - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
-          - "traefik.http.routers.odoo-route.service=odoo-service"
-          - "traefik.http.routers.odoo-route.entrypoints=webssl"
-          - "traefik.http.routers.odoo-route.tls=true"
-          - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
-          - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
-          - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
-          - "traefik.http.routers.odoo-ge-route.entrypoints=webssl"
-          - "traefik.http.routers.odoo-ge-route.tls=true"
-          - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
-
+            # Route all HTTPS traffic to Odoo on port 8069.
+            - "traefik.enable=true"
+            - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
+            - "traefik.http.routers.odoo-route.service=odoo-service"
+            - "traefik.http.routers.odoo-route.entrypoints=webssl"
+            - "traefik.http.routers.odoo-route.tls=true"
+            - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
+            # Route /websocket traffic to the Gevent worker on port 8072.
+            - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
+            - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
+            - "traefik.http.routers.odoo-ge-route.entrypoints=webssl"
+            - "traefik.http.routers.odoo-ge-route.tls=true"
+            - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
         depends_on:
-            - odood-example-ssl-db
+            odood-example-ssl-db:
+                # Wait until PostgreSQL is healthy before starting Odoo.
+                condition: service_healthy
         environment:
+            # Database connection — must match POSTGRES_USER/PASSWORD above.
             ODOOD_OPT_DB_HOST: odood-example-ssl-db
             ODOOD_OPT_DB_USER: odoo
             ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+            # Odoo master password used to create/drop databases via the web UI.
             ODOOD_OPT_ADMIN_PASSWD: admin
-            ODOOD_OPT_WORKERS: "1"
-            ODOOD_OPT_PROXY_MODE: True
+            # Number of Odoo worker processes. Increase for higher load.
+            # Rule of thumb: (CPU cores * 2) + 1, minimum 2.
+            ODOOD_OPT_WORKERS: "2"
+            # Required when Odoo runs behind a reverse proxy.
+            ODOOD_OPT_PROXY_MODE: "True"
         volumes:
             - odood-example-ssl-odoo-data:/opt/odoo/data
-        restart: "no"
+        restart: unless-stopped
 
     odood-example-ssl-traefik:
-      image: "traefik:v3.2"
-      container_name: "odood-example-ssl-traefik"
-      command:
-        #- "--log.level=DEBUG"
-        #- "--api.insecure=true"
-        - "--providers.docker=true"
-        - "--providers.docker.exposedbydefault=false"
-        - "--providers.file.filename=/traefik-certs.yml"
-        - "--entryPoints.web.address=:80"
-        - "--entryPoints.webssl.address=:443"
-        - "--entrypoints.web.http.redirections.entrypoint.to=webssl"
-        - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
-      ports:
-        - "80:80"
-        - "443:443"
-        - "8080:8080"
-      volumes:
-        - "./traefik/traefik-certs.yml:/traefik-certs.yml"
-        - "./traefik/certs/:/certs/"
-        - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
-
+        image: "traefik:v3.2"
+        container_name: "odood-example-ssl-traefik"
+        command:
+            #- "--log.level=DEBUG"
+            - "--providers.docker=true"
+            - "--providers.docker.exposedbydefault=false"
+            # Load TLS certificate configuration from the mounted file.
+            - "--providers.file.filename=/traefik-certs.yml"
+            - "--entryPoints.web.address=:80"
+            - "--entryPoints.webssl.address=:443"
+            # Redirect all HTTP traffic to HTTPS.
+            - "--entrypoints.web.http.redirections.entrypoint.to=webssl"
+            - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+        ports:
+            - "80:80"
+            - "443:443"
+        volumes:
+            - "./traefik/traefik-certs.yml:/traefik-certs.yml"
+            - "./traefik/certs/:/certs/"
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        restart: unless-stopped

--- a/examples/docker-compose/odoo-and-db/docker-compose.yml
+++ b/examples/docker-compose/odoo-and-db/docker-compose.yml
@@ -1,4 +1,12 @@
-version: '3'
+# Odood Docker Compose Example — HTTP
+#
+# Runs Odoo 18 with PostgreSQL behind a Traefik reverse proxy over plain HTTP.
+#
+# Usage:
+#   docker compose up -d
+#
+# Odoo will be available at http://localhost
+# Traefik dashboard at http://localhost:8080 (disable in production)
 
 volumes:
     odood-example-db-data:
@@ -6,58 +14,73 @@ volumes:
 
 services:
     odood-example-db:
-        image: postgres:15
+        image: postgres:16
         container_name: odood-example-db
         environment:
-            - POSTGRES_USER=odoo
-            - POSTGRES_PASSWORD=odoo-db-pass
-
-            # this is needed to avoid auto-creation of database by postgres itself
-            # databases must be created by Odoo only
-            - POSTGRES_DB=postgres
+            # Credentials must match ODOOD_OPT_DB_USER / ODOOD_OPT_DB_PASSWORD below.
+            POSTGRES_USER: odoo
+            POSTGRES_PASSWORD: odoo-db-pass
+            # Prevents PostgreSQL from auto-creating a default database;
+            # all Odoo databases must be created by Odoo itself.
+            POSTGRES_DB: postgres
         volumes:
             - odood-example-db-data:/var/lib/postgresql/data
-        restart: "no"
+        healthcheck:
+            test: ["CMD-SHELL", "pg_isready -U odoo"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+            start_period: 10s
+        restart: unless-stopped
 
     odood-example-odoo:
-        image: ghcr.io/katyukha/odood/odoo/17.0:latest
+        image: ghcr.io/katyukha/odood/odoo/18.0:latest
         container_name: odood-example-odoo
         labels:
-          - "traefik.enable=true"
-          - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
-          - "traefik.http.routers.odoo-route.service=odoo-service"
-          - "traefik.http.routers.odoo-route.entrypoints=web"
-          - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
-          - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
-          - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
-          - "traefik.http.routers.odoo-ge-route.entrypoints=web"
-          - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
-
+            # Route all HTTP traffic to Odoo on port 8069.
+            - "traefik.enable=true"
+            - "traefik.http.routers.odoo-route.rule=Host(`localhost`)"
+            - "traefik.http.routers.odoo-route.service=odoo-service"
+            - "traefik.http.routers.odoo-route.entrypoints=web"
+            - "traefik.http.services.odoo-service.loadbalancer.server.port=8069"
+            # Route /websocket traffic to the Gevent worker on port 8072.
+            - "traefik.http.routers.odoo-ge-route.rule=Host(`localhost`) && Path(`/websocket`)"
+            - "traefik.http.routers.odoo-ge-route.service=odoo-ge-service"
+            - "traefik.http.routers.odoo-ge-route.entrypoints=web"
+            - "traefik.http.services.odoo-ge-service.loadbalancer.server.port=8072"
         depends_on:
-            - odood-example-db
+            odood-example-db:
+                # Wait until PostgreSQL is healthy before starting Odoo.
+                condition: service_healthy
         environment:
+            # Database connection — must match POSTGRES_USER/PASSWORD above.
             ODOOD_OPT_DB_HOST: odood-example-db
             ODOOD_OPT_DB_USER: odoo
             ODOOD_OPT_DB_PASSWORD: odoo-db-pass
+            # Odoo master password used to create/drop databases via the web UI.
             ODOOD_OPT_ADMIN_PASSWD: admin
-            ODOOD_OPT_WORKERS: "1"
-            ODOOD_OPT_PROXY_MODE: True
+            # Number of Odoo worker processes. Increase for higher load.
+            # Rule of thumb: (CPU cores * 2) + 1, minimum 2.
+            ODOOD_OPT_WORKERS: "2"
+            # Required when Odoo runs behind a reverse proxy.
+            ODOOD_OPT_PROXY_MODE: "True"
         volumes:
             - odood-example-odoo-data:/opt/odoo/data
-        restart: "no"
+        restart: unless-stopped
 
     odood-example-traefik:
-      image: "traefik:v3.2"
-      container_name: "odood-example-traefik"
-      command:
-        #- "--log.level=DEBUG"
-        - "--api.insecure=true"
-        - "--providers.docker=true"
-        - "--providers.docker.exposedbydefault=false"
-        - "--entryPoints.web.address=:80"
-      ports:
-        - "80:80"
-        - "8080:8080"
-      volumes:
-        - "/var/run/docker.sock:/var/run/docker.sock:ro"
-
+        image: "traefik:v3.2"
+        container_name: "odood-example-traefik"
+        command:
+            #- "--log.level=DEBUG"
+            - "--api.insecure=true"
+            - "--providers.docker=true"
+            - "--providers.docker.exposedbydefault=false"
+            - "--entryPoints.web.address=:80"
+        ports:
+            - "80:80"
+            # Traefik dashboard — remove in production.
+            - "8080:8080"
+        volumes:
+            - "/var/run/docker.sock:/var/run/docker.sock:ro"
+        restart: unless-stopped

--- a/subpackages/cli/dub.selections.json
+++ b/subpackages/cli/dub.selections.json
@@ -7,7 +7,7 @@
 		"cachetools": "0.4.2",
 		"colored": "0.0.31",
 		"commandr": "1.1.0",
-		"darktemple": "0.0.8",
+		"darktemple": "0.0.9",
 		"dini": "2.0.0",
 		"dpq": "0.11.6",
 		"dshould": "1.8.0",

--- a/subpackages/cli/dub.selections.json
+++ b/subpackages/cli/dub.selections.json
@@ -20,7 +20,7 @@
 		"tabletool": "0.5.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.1.0",
+		"theprocess": "0.1.1",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.1.9",
 		"versioned": "0.1.0",

--- a/subpackages/cli/dub.selections.json
+++ b/subpackages/cli/dub.selections.json
@@ -20,7 +20,7 @@
 		"tabletool": "0.5.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.0.10",
+		"theprocess": "0.1.0",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.1.9",
 		"versioned": "0.1.0",

--- a/subpackages/cli/source/odood/cli/app.d
+++ b/subpackages/cli/source/odood/cli/app.d
@@ -138,7 +138,7 @@ class App: OdoodProgram {
             import std.process: environment;
             import std.string: chompPrefix, toLower, startsWith;
             infof("Applying configuration from env variables to Odoo config...");
-            auto config = project.get.getOdooConfig;
+            auto config = project.get.server.getConfig;
             foreach(kv; environment.toAA.byKeyValue) {
                 if (!kv.key.toLower.startsWith("odood_opt_"))
                     // Skip options that not related to Odood

--- a/subpackages/cli/source/odood/cli/commands/addons.d
+++ b/subpackages/cli/source/odood/cli/commands/addons.d
@@ -8,7 +8,7 @@ private import std.algorithm;
 private import std.conv: to;
 private import std.string: capitalize, strip, join;
 private import std.regex;
-private import std.array: array;
+private import std.array: array, empty;
 
 private import thepath: Path;
 private import commandr: Argument, Option, Flag, ProgramArgs, acceptsValues;
@@ -419,11 +419,37 @@ class CommandAddonsUpdateInstallUninstall: OdoodCommand {
         this.add(
             new Flag(
                 null, "skip-errors", "Do not fail on errors during installation."));
+        this.add(
+            new Flag(
+                null, "ignore-unfinished-updates",
+                "Do not fail if there are unfinished addon install/update/uninstall operations."));
 
         // Start server after update (if everythign is ok)
         this.add(
             new Flag(
                 null, "start", "Start server after update (if everything is ok)"));
+    }
+
+    /** Check for unfinished addon operations in the database.
+      * By default throws if any are found; pass --ignore-unfinished-updates to warn only.
+      **/
+    protected void checkUnfinishedUpdates(
+            in Project project,
+            in string dbname,
+            ProgramArgs args) {
+        auto unfinished = project.databases[dbname].getUnfinishedUpdates();
+        if (unfinished.length == 0)
+            return;
+        warningf(
+            "Database '%s' has %s unfinished install/update/uninstall operation(s): %s",
+            dbname,
+            unfinished.length,
+            unfinished.map!(u => "%s (state=%s, available=%s)".format(
+                u.addon_name, u.addon_state, u.is_available)).join(", "));
+        if (!args.flag("ignore-unfinished-updates"))
+            throw new OdoodCLIException(
+                "Database '%s' has unfinished addon operations. ".format(dbname) ~
+                "Use --ignore-unfinished-updates to proceed anyway.");
     }
 
     /** Find addons
@@ -526,18 +552,33 @@ class CommandAddonsUpdate: CommandAddonsUpdateInstallUninstall {
         this.add(
             new Flag(
                 "a", "all", "Update all modules"));
+        this.add(
+            new Flag(
+                null, "installed-only",
+                "Skip addons that are not installed in the database."));
     }
 
     public override void execute(ProgramArgs args) {
         auto project = Project.loadProject;
 
         applyForDatabases(args, project, (in string dbname) {
+            checkUnfinishedUpdates(project, dbname, args);
             if (args.flag("ual"))
                 project.lodoo.addonsUpdateList(dbname, true);
             if (args.flag("all"))
                 project.addons.updateAll(dbname);
-            else
-                project.addons.update(dbname, findAddons(args, project));
+            else {
+                auto addons = findAddons(args, project);
+                if (args.flag("installed-only"))
+                    addons = addons
+                        .filter!(a => project.addons.isInstalled(dbname, a))
+                        .array;
+                if (addons.empty)
+                    infof("No installed addons to update in %s, skipping.", dbname);
+                else
+                    project.addons.update(dbname, addons);
+            }
+            checkUnfinishedUpdates(project, dbname, args);
         });
     }
 
@@ -550,15 +591,29 @@ class CommandAddonsInstall: CommandAddonsUpdateInstallUninstall {
         this.add(
             new Flag(
                 null, "ual", "Update addons list before install."));
+        this.add(
+            new Flag(
+                null, "missing-only",
+                "Skip addons that are already installed in the database."));
     }
 
     public override void execute(ProgramArgs args) {
         auto project = Project.loadProject;
 
         applyForDatabases(args, project, (in string dbname) {
+            checkUnfinishedUpdates(project, dbname, args);
             if (args.flag("ual"))
                 project.lodoo.addonsUpdateList(dbname, true);
-            project.addons.install(dbname, findAddons(args, project));
+            auto addons = findAddons(args, project);
+            if (args.flag("missing-only"))
+                addons = addons
+                    .filter!(a => !project.addons.isInstalled(dbname, a))
+                    .array;
+            if (addons.empty)
+                infof("All addons already installed in %s, skipping.", dbname);
+            else
+                project.addons.install(dbname, addons);
+            checkUnfinishedUpdates(project, dbname, args);
         });
     }
 }

--- a/subpackages/cli/source/odood/cli/commands/assembly.d
+++ b/subpackages/cli/source/odood/cli/commands/assembly.d
@@ -35,9 +35,10 @@ class CommandAssemblyInit: OdoodCommand {
             "Assembly already initialized!");
         if (args.option("repo").empty)
             project.initializeAssembly();
-        else
+        else {
             project.initializeAssembly(parseGitURL(args.option("repo")));
             project.assembly.get.link();
+        }
     }
 }
 

--- a/subpackages/cli/source/odood/cli/commands/database.d
+++ b/subpackages/cli/source/odood/cli/commands/database.d
@@ -158,6 +158,31 @@ class CommandDatabaseExists: OdoodCommand {
 }
 
 
+class CommandDatabaseIsInitialized: OdoodCommand {
+    this() {
+        super("is-initialized",
+            "Check if database is initialized as an Odoo database.");
+        this.add(new Flag(
+            "q", "quiet", "Suppress output, just return exit code."));
+        this.add(new Argument("name", "Name of database.").required());
+    }
+
+    public override void execute(ProgramArgs args) {
+        auto project = Project.loadProject;
+        bool initialized = project.databases.isInitialized(args.arg("name"));
+        if (initialized) {
+            if (!args.flag("quiet"))
+                writeln("Database %s is initialized.".format(args.arg("name")));
+            exitWithCode(0, "Database is initialized");
+        } else {
+            if (!args.flag("quiet"))
+                writeln("Database %s is not initialized.".format(args.arg("name")));
+            exitWithCode(1, "Database is not initialized");
+        }
+    }
+}
+
+
 class CommandDatabaseRename: OdoodCommand {
     this() {
         super("rename", "Rename database.");
@@ -353,6 +378,7 @@ class CommandDatabase: OdoodCommand {
         this.add(new CommandDatabaseCreate());
         this.add(new CommandDatabaseDrop());
         this.add(new CommandDatabaseExists());
+        this.add(new CommandDatabaseIsInitialized());
         this.add(new CommandDatabaseRename());
         this.add(new CommandDatabaseCopy());
         this.add(new CommandDatabaseBackup());

--- a/subpackages/cli/source/odood/cli/commands/database.d
+++ b/subpackages/cli/source/odood/cli/commands/database.d
@@ -1,5 +1,6 @@
 module odood.cli.commands.database;
 
+private import core.time;
 private import std.logger;
 private import std.stdio: writeln;
 private import std.format: format;
@@ -371,11 +372,52 @@ class CommandDatabasePopulate: OdoodCommand {
 }
 
 
+class CommandDatabaseEnsureInitialized: OdoodCommand {
+    this() {
+        super("ensure-initialized",
+              "Ensure a database exists and is initialized as an Odoo database. " ~
+              "Idempotent: safe to use in K8s init containers.");
+        this.add(new Flag(
+            null, "wait-pg",
+            "Wait for PostgreSQL to be ready before proceeding."));
+        this.add(new Option(
+            null, "wait-pg-timeout",
+            "Maximum time to wait for PostgreSQL in seconds.")
+            .defaultValue("60"));
+        this.add(new Flag("d", "demo", "Load demo data (only on first initialization)."));
+        this.add(new Option(
+            "l", "lang",
+            "Language code, e.g. en_US (only on first initialization).")
+            .defaultValue("en_US"));
+        this.add(new Argument("name", "Name of database.").required());
+    }
+
+    public override void execute(ProgramArgs args) {
+        auto project = Project.loadProject;
+
+        if (args.flag("wait-pg")) {
+            auto pg_timeout = args.option("wait-pg-timeout").to!long.seconds;
+            infof("Waiting for PostgreSQL...");
+            enforce!OdoodCLIException(
+                project.server.waitForPostgres(pg_timeout),
+                "PostgreSQL did not become available within the timeout.");
+            infof("PostgreSQL is ready.");
+        }
+
+        project.databases.ensureInitialized(
+            args.arg("name"),
+            args.flag("demo"),
+            args.option("lang"));
+    }
+}
+
+
 class CommandDatabase: OdoodCommand {
     this() {
         super("db", "Database management commands");
         this.add(new CommandDatabaseList());
         this.add(new CommandDatabaseCreate());
+        this.add(new CommandDatabaseEnsureInitialized());
         this.add(new CommandDatabaseDrop());
         this.add(new CommandDatabaseExists());
         this.add(new CommandDatabaseIsInitialized());

--- a/subpackages/cli/source/odood/cli/commands/deploy.d
+++ b/subpackages/cli/source/odood/cli/commands/deploy.d
@@ -69,6 +69,11 @@ class CommandDeploy: OdoodCommand {
             null, "local-nginx-ssl-key", "Path to SSL key for local nginx."));
 
         this.add(new Flag(
+            null, "tls12-compat",
+            "Allow TLS 1.2 in addition to TLS 1.3 for backward compatibility with older clients. " ~
+            "By default, only TLS 1.3 is enabled."));
+
+        this.add(new Flag(
             null, "letsencrypt", "Enable Let's Encrypt configuration."));
         this.add(new Option(
             null, "letsencrypt-email", "Email for Let's Encrypt account."));
@@ -153,6 +158,9 @@ class CommandDeploy: OdoodCommand {
 
             config.odoo.proxy_mode = true;
             config.odoo.http_host = "127.0.0.1";
+
+            if (args.flag("tls12-compat"))
+                config.nginx.tls12_compat = true;
         }
         if (args.flag("letsencrypt") || !args.option("letsencrypt-email").empty) {
             config.letsencrypt_enable = true;

--- a/subpackages/cli/source/odood/cli/commands/deploy.d
+++ b/subpackages/cli/source/odood/cli/commands/deploy.d
@@ -26,6 +26,7 @@ private import odood.utils: generateRandomString;
 private import odood.git: GitURL;
 
 private import odood.lib.deploy;
+private import odood.lib.deploy.config: detectSystemCABundle;
 
 
 class CommandDeploy: OdoodCommand {
@@ -91,6 +92,11 @@ class CommandDeploy: OdoodCommand {
 
         this.add(new Flag(
             null, "log-to-stderr", "Log to stderr. Useful when running inside docker."));
+
+        this.add(new Flag(
+            null, "use-system-ca-bundle",
+            "Set REQUESTS_CA_BUNDLE to the system CA certificate store, " ~
+            "so Odoo uses system certificates instead of the bundled certifi CA bundle."));
 
         this.add(new Option(
             null, "assembly-repo",
@@ -191,6 +197,11 @@ class CommandDeploy: OdoodCommand {
 
         if (args.flag("log-to-stderr"))
             config.odoo.log_to_stderr = true;
+
+        if (args.flag("use-system-ca-bundle")) {
+            config.odoo.use_system_ca_bundle = true;
+            config.odoo.system_ca_bundle_path = detectSystemCABundle();
+        }
 
         if (!args.option("assembly-repo").empty)
             config.assembly_repo = GitURL(args.option("assembly-repo")).nullable;

--- a/subpackages/cli/source/odood/cli/commands/init.d
+++ b/subpackages/cli/source/odood/cli/commands/init.d
@@ -6,7 +6,7 @@ private import std.exception: enforce;
 private import std.string: empty;
 
 private import thepath: Path;
-private import theprocess: resolveProgram;
+private import theprocess: resolveProgram, systemUserExists;
 private import commandr: Option, Flag, ProgramArgs, acceptsValues;
 
 private import odood.cli.core: OdoodCommand, OdoodCLIException;
@@ -16,7 +16,6 @@ private import odood.lib.project: Project, OdooInstallType;
 private import odood.lib.odoo.config: initOdooConfig;
 private import odood.lib.postgres: createNewPostgresUser;
 private import odood.utils.odoo.serie: OdooSerie;
-private import odood.utils: checkSystemUserExists;
 
 
 class CommandInit: OdoodCommand {
@@ -95,7 +94,7 @@ class CommandInit: OdoodCommand {
         if (args.flag("create-db-user"))
             // Check if we can create pg user if requested, before initialization started.
             enforce!OdoodCLIException(
-                checkSystemUserExists("postgres"),
+                systemUserExists("postgres"),
                 "Local 'postgresql' package seems not installed, thus cannot create pg user for Odoo!");
 
 

--- a/subpackages/cli/source/odood/cli/commands/repository.d
+++ b/subpackages/cli/source/odood/cli/commands/repository.d
@@ -334,25 +334,25 @@ class CommandRepositoryDoForwardPort: OdoodCommand {
 
         // Prepare merge
         if (!repo.gitCmd
-                .addArgs("merge", "--no-ff", "--no-commit", "--edit", "origin/%s".format(source_branch))
+                .withArgs("merge", "--no-ff", "--no-commit", "--edit", "origin/%s".format(source_branch))
                 .execute.isOk)
             warningf("Merge failed, there are conflicts. Please, resolve them manually");
 
         // Revert translation changes
         repo.gitCmd
-            .addArgs("reset", "-q", "--", "*.po", "*.pot")
+            .withArgs("reset", "-q", "--", "*.po", "*.pot")
             .execute
             .ensureOk(true);
 
         repo.gitCmd
-            .addArgs("clean", "-fdx", " --", "*.po", "*.pot")
+            .withArgs("clean", "-fdx", " --", "*.po", "*.pot")
             .execute
             .ensureOk(true);
         repo.gitCmd
-            .addArgs("checkout", "--ours", "--", "*.po", "*.pot")
+            .withArgs("checkout", "--ours", "--", "*.po", "*.pot")
             .execute;
         repo.gitCmd
-            .addArgs("add", "*.po", "*.pot")
+            .withArgs("add", "*.po", "*.pot")
             .execute;
 
         // Fix version conflicts

--- a/subpackages/cli/source/odood/cli/commands/server.d
+++ b/subpackages/cli/source/odood/cli/commands/server.d
@@ -130,28 +130,7 @@ class CommandServerBrowse: OdoodCommand {
         if (!project.server.isRunning)
             project.server.start;
 
-        auto odoo_conf = project.getOdooConfig;
-
-        /** Get option with default value
-          **/
-        string get_option(
-                in string name,
-                lazy string default_val) {
-            if (odoo_conf["options"].hasKey(name))
-                return odoo_conf["options"].getKey(name);
-            return default_val;
-        }
-
-        string url = "http://%s:%s/".format(
-            get_option(
-                "http_interface",
-                get_option(
-                    "xmlrpc_interface", "localhost")),
-            get_option(
-                "http_port",
-                get_option(
-                    "xmlrpc_port", "8069"))
-        );
+        auto url = project.server.getConfigHTTP.url;
         infof("Opening %s in browse....", url);
         std.process.browse(url);
     }

--- a/subpackages/cli/source/odood/cli/commands/server.d
+++ b/subpackages/cli/source/odood/cli/commands/server.d
@@ -177,6 +177,32 @@ class CommandServerLogView: OdoodCommand {
 }
 
 
+class CommandServerHealthcheck: OdoodCommand {
+    this() {
+        super("healthcheck",
+            "Check if the Odoo HTTP server is healthy.\n" ~
+            "Exits 0 if healthy, 1 if not.\n");
+        this.add(new Option(
+            "t", "timeout",
+            "HTTP request timeout in seconds.")
+            .defaultValue("10"));
+    }
+
+    public override void execute(ProgramArgs args) {
+        import std.stdio: writeln;
+        import core.time: seconds;
+
+        auto project = Project.loadProject;
+        auto timeout = args.option("timeout").to!long.seconds;
+
+        if (project.server.healthcheck(timeout))
+            infof("Odoo server is healthy.");
+        else
+            throw new OdoodCLIException("Odoo server is not healthy!");
+    }
+}
+
+
 class CommandServer: OdoodCommand {
     this() {
         super("server", "Server management commands.");
@@ -187,6 +213,7 @@ class CommandServer: OdoodCommand {
         this.add(new CommandServerRestart());
         this.add(new CommandServerBrowse());
         this.add(new CommandServerLogView());
+        this.add(new CommandServerHealthcheck());
     }
 }
 

--- a/subpackages/cli/source/odood/cli/commands/server.d
+++ b/subpackages/cli/source/odood/cli/commands/server.d
@@ -22,6 +22,13 @@ class CommandServerRun: OdoodCommand {
         super("run", "Run the server.");
         this.add(new Flag(
             null, "ignore-running", "Ingore running Odoo instance. (Do not check/create pidfile)."));
+        this.add(new Flag(
+            null, "wait-pg",
+            "Wait for PostgreSQL to be ready before starting the server."));
+        this.add(new Option(
+            null, "wait-pg-timeout",
+            "Maximum time to wait for PostgreSQL in seconds.")
+            .defaultValue("60"));
     }
 
     public override void execute(ProgramArgs args) {
@@ -39,6 +46,15 @@ class CommandServerRun: OdoodCommand {
             enforce!OdoodCLIException(
                 !project.server.isRunning,
                 "Odoo server already running!");
+        }
+
+        if (args.flag("wait-pg")) {
+            auto pg_timeout = args.option("wait-pg-timeout").to!long.seconds;
+            infof("Waiting for PostgreSQL...");
+            enforce!OdoodCLIException(
+                project.server.waitForPostgres(pg_timeout),
+                "PostgreSQL did not become available within the timeout.");
+            infof("PostgreSQL is ready.");
         }
 
         debug tracef("Running Odoo: %s", runner);
@@ -182,6 +198,33 @@ class CommandServerHealthcheck: OdoodCommand {
 }
 
 
+class CommandServerWaitPg: OdoodCommand {
+    this() {
+        super("wait-pg", "Wait for PostgreSQL to become available.");
+        this.add(new Option(
+            "t", "timeout",
+            "Maximum time to wait in seconds.")
+            .defaultValue("60"));
+        this.add(new Option(
+            null, "interval",
+            "Time between connection attempts in seconds.")
+            .defaultValue("2"));
+    }
+
+    public override void execute(ProgramArgs args) {
+        auto project = Project.loadProject;
+        auto timeout = args.option("timeout").to!long.seconds;
+        auto interval = args.option("interval").to!long.seconds;
+
+        infof("Waiting for PostgreSQL...");
+        enforce!OdoodCLIException(
+            project.server.waitForPostgres(timeout, interval),
+            "PostgreSQL did not become available within the timeout.");
+        infof("PostgreSQL is ready.");
+    }
+}
+
+
 class CommandServer: OdoodCommand {
     this() {
         super("server", "Server management commands.");
@@ -193,6 +236,7 @@ class CommandServer: OdoodCommand {
         this.add(new CommandServerBrowse());
         this.add(new CommandServerLogView());
         this.add(new CommandServerHealthcheck());
+        this.add(new CommandServerWaitPg());
     }
 }
 

--- a/subpackages/cli/source/odood/cli/commands/status.d
+++ b/subpackages/cli/source/odood/cli/commands/status.d
@@ -35,20 +35,6 @@ class CommandStatus: OdoodCommand {
     public override void execute(ProgramArgs args) {
         auto project = Project.loadProject;
 
-        auto odoo_config = project.getOdooConfig();
-
-        string http_host = "localhost";
-        if (odoo_config["options"].hasKey("http_interface"))
-            http_host = odoo_config["options"].getKey("http_interface");
-        else if (odoo_config["options"].hasKey("xmlrpc_interface"))
-            http_host = odoo_config["options"].getKey("xmlrpc_interface");
-
-        string http_port = "8069";
-        if (odoo_config["options"].hasKey("http_port"))
-            http_port = odoo_config["options"].getKey("http_port");
-        else if (odoo_config["options"].hasKey("xmlrpc_port"))
-            http_port = odoo_config["options"].getKey("xmlrpc_port");
-
         writeln(
             TMPL_CURRENT_PROJECT_STATUS.format(
                 project.project_root.toString.blue,
@@ -56,7 +42,7 @@ class CommandStatus: OdoodCommand {
                 project.odoo.serie.toString.green,
                 project.odoo.branch.green,
                 project.server.isRunning ? "Running".green : "Stopped".red,
-                "http://%s:%s".format(http_host, http_port).lightBlue,
+                project.server.getConfigHTTP.url.lightBlue,
             )
         );
     }

--- a/subpackages/cli/source/odood/cli/commands/test.d
+++ b/subpackages/cli/source/odood/cli/commands/test.d
@@ -254,7 +254,7 @@ class CommandTest: OdoodCommand {
         // Handle coverage report
         if (coverage)
             project.venv.runner
-                .addArgs("coverage", "combine")
+                .withArgs("coverage", "combine")
                 .withFlag(std.process.Config.stderrPassThrough)
                 .inWorkDir(Path.current)
                 .execute

--- a/subpackages/cli/source/odood/cli/commands/venv.d
+++ b/subpackages/cli/source/odood/cli/commands/venv.d
@@ -69,8 +69,8 @@ class CommandVenvPIP: OdoodCommand {
 
     public override void execute(ProgramArgs args) {
         Project.loadProject.venv.runner
-            .addArgs("pip")
-            .addArgs(args.argsRest)
+            .withArgs("pip")
+            .withArgs(args.argsRest)
             .execv;
     }
 
@@ -85,8 +85,8 @@ class CommandVenvNPM: OdoodCommand {
 
     public override void execute(ProgramArgs args) {
         Project.loadProject.venv.runner
-            .addArgs("npm")
-            .addArgs(args.argsRest)
+            .withArgs("npm")
+            .withArgs(args.argsRest)
             .execv;
     }
 
@@ -107,8 +107,8 @@ class CommandVenvIPython: OdoodCommand {
             project.venv.installPyPackages("ipython");
 
         project.venv.runner
-            .addArgs("ipython")
-            .addArgs(args.argsRest)
+            .withArgs("ipython")
+            .withArgs(args.argsRest)
             .execv;
     }
 }
@@ -123,8 +123,8 @@ class CommandVenvPython: OdoodCommand {
     public override void execute(ProgramArgs args) {
         auto project = Project.loadProject;
         project.venv.runner
-            .addArgs("python")
-            .addArgs(args.argsRest)
+            .withArgs("python")
+            .withArgs(args.argsRest)
             .execv;
     }
 
@@ -145,7 +145,7 @@ class CommandVenvLOdoo: OdoodCommand {
             project.venv.installPyPackages("lodoo");
 
         project.lodoo.runner
-            .addArgs(args.argsRest)
+            .withArgs(args.argsRest)
             .execv;
     }
 }
@@ -162,7 +162,7 @@ class CommandVenvRun: OdoodCommand {
     }
 
     public override void execute(ProgramArgs args) {
-        Project.loadProject.venv.runner.addArgs(args.argsRest).execv;
+        Project.loadProject.venv.runner.withArgs(args.argsRest).execv;
     }
 
 }

--- a/subpackages/git/dub.sdl
+++ b/subpackages/git/dub.sdl
@@ -5,7 +5,7 @@ copyright "Copyright © 2022-2023, Dmytro Katyukha"
 license "MPL-2.0"
 
 dependency "thepath" version=">=1.2.0"
-dependency "theprocess" version=">=0.1.0"
+dependency "theprocess" version=">=0.1.1"
 
 targetPath "build"
 targetType "library"

--- a/subpackages/git/dub.sdl
+++ b/subpackages/git/dub.sdl
@@ -5,7 +5,7 @@ copyright "Copyright © 2022-2023, Dmytro Katyukha"
 license "MPL-2.0"
 
 dependency "thepath" version=">=1.2.0"
-dependency "theprocess" version=">=0.0.9"
+dependency "theprocess" version=">=0.1.0"
 
 targetPath "build"
 targetType "library"

--- a/subpackages/git/dub.selections.json
+++ b/subpackages/git/dub.selections.json
@@ -5,7 +5,7 @@
 		"odood": {"path":"../../"},
 		"prettyprint": "1.0.9",
 		"thepath": "2.2.0",
-		"theprocess": "0.0.10",
+		"theprocess": "0.1.0",
 		"unit-threaded": "2.2.3"
 	}
 }

--- a/subpackages/git/dub.selections.json
+++ b/subpackages/git/dub.selections.json
@@ -5,7 +5,7 @@
 		"odood": {"path":"../../"},
 		"prettyprint": "1.0.9",
 		"thepath": "2.2.0",
-		"theprocess": "0.1.0",
+		"theprocess": "0.1.1",
 		"unit-threaded": "2.2.3"
 	}
 }

--- a/subpackages/git/source/odood/git/package.d
+++ b/subpackages/git/source/odood/git/package.d
@@ -58,8 +58,8 @@ bool isGitRepo(in Path path) {
         return true;
 
     const auto result = Process("git")
-        .setArgs("rev-parse", "--git-dir")
-        .setWorkDir(path)
+        .withArgs("rev-parse", "--git-dir")
+        .inWorkDir(path)
         .execute();
     if (result.status == 0)
         return true;

--- a/subpackages/git/source/odood/git/repository.d
+++ b/subpackages/git/source/odood/git/repository.d
@@ -179,6 +179,16 @@ class GitRepository {
         return getRemoteUrl("origin");
     }
 
+    /** Check if repo has local branch with specified name
+      **/
+    bool hasLocalBranch(in string name) const {
+        return gitCmd
+            .withArgs("show-ref", "--verify", "--quiet", "refs/heads/%s".format(name))
+            .withFlag(std.process.Config.stderrPassThrough)
+            .execute
+            .isOk;
+    }
+
     /** Switch repo to specified branch
       **/
     void switchBranchTo(in string branch_name, in bool create=false) const {

--- a/subpackages/git/source/odood/git/repository.d
+++ b/subpackages/git/source/odood/git/repository.d
@@ -114,7 +114,7 @@ class GitRepository {
     Nullable!string getCurrBranch() const {
         auto result = gitCmd
             .withArgs(["symbolic-ref", "-q", "HEAD"])
-            .setFlag(std.process.Config.Flags.stderrPassThrough)
+            .withFlag(std.process.Config.Flags.stderrPassThrough)
             .execute();
         if (result.status == 0)
             return result.output.strip().chompPrefix("refs/heads/").nullable;
@@ -129,7 +129,7 @@ class GitRepository {
     string getCurrCommit() const {
         return gitCmd
             .withArgs(["rev-parse", "-q", "HEAD"])
-            .setFlag(std.process.Config.stderrPassThrough)
+            .withFlag(std.process.Config.stderrPassThrough)
             .execute()
             .ensureStatus(true)
             .output.strip();
@@ -147,7 +147,7 @@ class GitRepository {
     /// ditto
     void fetchOrigin(in string branch) const {
         gitCmd
-            .setArgs("fetch", "origin", branch)
+            .withArgs("fetch", "origin", branch)
             .execute()
             .ensureStatus(true);
     }
@@ -156,7 +156,7 @@ class GitRepository {
       **/
     auto hasRemoteUrl(in string name) const {
         return gitCmd
-            .setArgs("remote", "get-url", name)
+            .withArgs("remote", "get-url", name)
             .withFlag(std.process.Config.stderrPassThrough)
             .execute
             .isOk;
@@ -166,7 +166,7 @@ class GitRepository {
       **/
     auto getRemoteUrl(in string name) const {
         string res = gitCmd
-            .setArgs("remote", "get-url", name)
+            .withArgs("remote", "get-url", name)
             .withFlag(std.process.Config.stderrPassThrough)
             .execute
             .ensureOk(true)
@@ -184,12 +184,12 @@ class GitRepository {
     void switchBranchTo(in string branch_name, in bool create=false) const {
         if (create)
             gitCmd
-                .setArgs("checkout", "-b", branch_name)
+                .withArgs("checkout", "-b", branch_name)
                 .execute()
                 .ensureStatus(true);
         else
             gitCmd
-                .setArgs("checkout", branch_name)
+                .withArgs("checkout", branch_name)
                 .execute()
                 .ensureStatus(true);
     }
@@ -306,14 +306,14 @@ class GitRepository {
             .withFlag(std.process.Config.stderrPassThrough);
 
         if (staged)
-            cmd = cmd.addArgs("--staged");
+            cmd.addArgs("--staged");
 
         // Prepeare command for git diff
         if (start_rev !is null) {
-            cmd = cmd.addArgs(prepareRevRange(start_rev, end_rev));
+            cmd.addArgs(prepareRevRange(start_rev, end_rev));
         }
         if (path_filters) {
-            cmd = cmd.addArgs(["--"] ~ path_filters);
+            cmd.addArgs(["--"] ~ path_filters);
         }
 
         return cmd.execute.ensureOk(true).output.splitLines.map!((p) => Path(p)).array;

--- a/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
+++ b/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
@@ -21,6 +21,9 @@ RUN odood addons link /opt/odoo/custom_addons && \
     odood venv python -- -m compileall -q /opt/odoo/custom_addons/ && \
     rm /tmp/odood-assembly-requirements.txt && \
     rm -rf /root/.cache/pip/
+{% else %}
+RUN odood addons link /opt/odoo/custom_addons && \
+    odood venv python -- -m compileall -q /opt/odoo/custom_addons/
 {% endif %}
 
 LABEL odoo.serie="{{ assembly.serie }}"

--- a/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
+++ b/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
@@ -3,27 +3,28 @@
 FROM ghcr.io/katyukha/odood/odoo/{{ assembly.serie }}:{% if is_dev_version %}latest{% else %}{{ _version }}{% endif %}
 
 {% if assembly.spec.layout == AssemblyLayout.STANDARD %}
-COPY {{ assembly.dist_dir }} /opt/odoo/custom_addons/
-{% elif assembly.spec.layout == AssemblyLayout.FLAT %}
-# WARNING: Building docker images on assemblies with FLAT layout type is not recommended.
-#          Please, switch to standard layout, is you need to build docker images.
-{% for addon; assembly.spec.addons %}
-COPY {{ addon.name }} /opt/odoo/custom_addons/{{ addon.name }}
-{% endfor %}
-{% else %}
-# Layout {{ assembly.spec.layout }} not supported for in docker yet
+# Copy the assembly spec and addons into a dedicated directory.
+# The spec file is required so that 'odood assembly use' can register the assembly
+# in odood.yml, which makes '--assembly' available for addon install/update commands
+# inside the container.
+COPY odood-assembly.yml /opt/odoo/assembly/odood-assembly.yml
+COPY dist/ /opt/odoo/assembly/dist/
+{% if handle_requirements_txt %}
+COPY requirements.txt /opt/odoo/assembly/requirements.txt
 {% endif %}
 
-{% if handle_requirements_txt %}
-COPY "requirements.txt" /tmp/odood-assembly-requirements.txt
-RUN odood addons link /opt/odoo/custom_addons && \
-    odood venv install-py-packages -r /tmp/odood-assembly-requirements.txt && \
-    odood venv python -- -m compileall -q /opt/odoo/custom_addons/ && \
-    rm /tmp/odood-assembly-requirements.txt && \
+# Register the assembly with the project, link addons into custom_addons/,
+# install Python requirements (handled automatically by 'assembly link'),
+# and pre-compile all addon Python files.
+RUN odood assembly use /opt/odoo/assembly && \
+    odood assembly link && \
+    odood venv python -- -m compileall -q /opt/odoo/assembly/dist/ && \
     rm -rf /root/.cache/pip/
+{% elif assembly.spec.layout == AssemblyLayout.FLAT %}
+# WARNING: Building Docker images from assemblies with FLAT layout is not supported.
+#          Switch to standard layout to build Docker images.
 {% else %}
-RUN odood addons link /opt/odoo/custom_addons && \
-    odood venv python -- -m compileall -q /opt/odoo/custom_addons/
+# Layout {{ assembly.spec.layout }} not supported for Docker yet.
 {% endif %}
 
 LABEL odoo.serie="{{ assembly.serie }}"

--- a/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
+++ b/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
@@ -35,4 +35,8 @@ LABEL org.opencontainers.image.source="{{ assembly_source_url }}"
 {% endif %}
 STOPSIGNAL SIGINT
 
+# HEALTHCHECK is inherited from the base Odood image.
+# It runs `odood server healthcheck` on a 30s interval with a 120s start period.
+# Override it here if the assembly requires different timing.
+
 # ---- ODOOD END DYNAMIC DOCKER CONFIG ----

--- a/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
+++ b/subpackages/lib/data/templates/assembly/Dockerfile.tmpl
@@ -23,4 +23,13 @@ RUN odood addons link /opt/odoo/custom_addons && \
     rm -rf /root/.cache/pip/
 {% endif %}
 
+LABEL odoo.serie="{{ assembly.serie }}"
+{% if assembly_version %}
+LABEL org.opencontainers.image.version="{{ assembly_version }}"
+{% endif %}
+{% if assembly_source_url %}
+LABEL org.opencontainers.image.source="{{ assembly_source_url }}"
+{% endif %}
+STOPSIGNAL SIGINT
+
 # ---- ODOOD END DYNAMIC DOCKER CONFIG ----

--- a/subpackages/lib/data/templates/assembly/changelog.md.tmpl
+++ b/subpackages/lib/data/templates/assembly/changelog.md.tmpl
@@ -32,9 +32,9 @@
 {% for addon; changes.notable_changes %}
 #### Addon `{{ addon.name }}`
 
-{% for entrie; addon.changelog %}
-##### Version {{ entrie.ver }}
-{{ entrie.data }}
+{% for entry; addon.changelog %}
+##### Version {{ entry.ver }}
+{{ entry.data }}
 
 {% endfor %}
 

--- a/subpackages/lib/data/templates/deploy/init.d.tmpl
+++ b/subpackages/lib/data/templates/deploy/init.d.tmpl
@@ -22,6 +22,9 @@ LOGFILE="{{ project.odoo.logfile }}"
 PIDFILE="{{project.odoo.pidfile }}.pid"
 USER="{{ project.odoo.server_user }}"
 export LOGNAME=$USER
+{% if !config.odoo.system_ca_bundle_path.isNull %}
+export REQUESTS_CA_BUNDLE={{ config.odoo.system_ca_bundle_path.get }}
+{% endif %}
 
 test -x $DAEMON || exit 0
 set -e

--- a/subpackages/lib/data/templates/deploy/nginx.conf.tmpl
+++ b/subpackages/lib/data/templates/deploy/nginx.conf.tmpl
@@ -1,11 +1,11 @@
 {% import std.format: format %}
 {% import std.range: empty %}
 upstream odoo_backend {
-        server {{ config.odoo.http_host.empty ? config.odoo.http_host : "127.0.0.1" }}:{{ config.odoo.http_port }} weight=1 fail_timeout=200s;
+        server {{ config.odoo.http_host.empty ? "127.0.0.1" : config.odoo.http_host }}:{{ config.odoo.http_port }} weight=1 fail_timeout=200s;
 }
 
 upstream odoo_websocket {
-        server {{ config.odoo.http_host.empty ? config.odoo.http_host : "127.0.0.1" }}:{{ config.odoo.websocket_port }} weight=1 fail_timeout=30s;
+        server {{ config.odoo.http_host.empty ? "127.0.0.1" : config.odoo.http_host }}:{{ config.odoo.websocket_port }} weight=1 fail_timeout=30s;
 }
 
 #------------------------------------------------------------------------------
@@ -22,6 +22,13 @@ server {
     listen   80;
     {{ config.nginx.server_name ? "server_name %s;".format(config.nginx.server_name) : ""}}
 
+    {% if config.letsencrypt_enable %}
+    # Allow ACME HTTP-01 challenges over plain HTTP (needed for certbot renewals)
+    location /.well-known/acme-challenge {
+        root {{ config.letsencrypt_webroot.toString }};
+    }
+    {% endif %}
+
     location / {
         return 301 https://$host$request_uri;
     }
@@ -36,6 +43,8 @@ server {
     {% endif %}
     {{ config.nginx.server_name ? "server_name %s;".format(config.nginx.server_name) : ""}}
 
+    server_tokens off;
+
     #-----------------------------------------------------------------------
     access_log  /var/log/nginx/odoo.access.log;
     error_log   /var/log/nginx/odoo.error.log;
@@ -46,8 +55,24 @@ server {
     # SSL config
     ssl_certificate     {{ config.nginx.ssl_cert }};
     ssl_certificate_key {{ config.nginx.ssl_key }};
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_ciphers         HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+    ssl_session_cache   shared:SSL:10m;
+    ssl_session_timeout 10m;
+    ssl_session_tickets off;
     #-----------------------------------------------------------------------
     {% endif %}
+
+    #-----------------------------------------------------------------------
+    # Security headers
+    {% if ssl_on %}
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    {% endif %}
+    add_header X-Content-Type-Options  "nosniff" always;
+    add_header Referrer-Policy         "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "frame-ancestors 'self'" always;
+    #-----------------------------------------------------------------------
 
     #-----------------------------------------------------------------------
     # global params for Odoo backend server section
@@ -72,27 +97,23 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header X-Real-IP $remote_addr;
 
-
     # by default, do not forward anything
     proxy_redirect off;
     proxy_buffering off;
 
-    # use gzip for folowing types
+    # use gzip for following types
+    gzip on;
     gzip_types text/html text/css text/less text/plain text/xml application/xml application/json application/javascript;
     #-----------------------------------------------------------------------
 
 
     location / {
-        # add_header Content-Security-Policy "upgrade-insecure-requests";
         proxy_pass http://odoo_backend;
     }
 
     # Chat and IM related features support
     {% if config.odoo.serie >= 16 %}
     location ~* ^/(websocket|bus) {
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
         proxy_pass http://odoo_websocket;
 
         # Upgrade connection
@@ -110,9 +131,6 @@ server {
     }
     {% else %}
     location /longpolling {
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
         proxy_pass http://odoo_websocket;
 
         # Increase timeouts for websockets
@@ -126,39 +144,28 @@ server {
     {% endif %}
 
 
-    # Restrict access
-    location ~* ^/(web/database/) {
-        # TODO: Restrict external access here
-        #    allow trusted_network;
-        #    allow trusted_ip;
-        #    deny all;
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
-        # deny all;
-        proxy_pass http://odoo_backend;
+    # Odoo database manager — blocked by default.
+    # To allow access from trusted IPs (e.g. VPN / admin network), replace
+    # "deny all" with:
+    #   allow <trusted_ip_or_cidr>;
+    #   deny all;
+    #   proxy_pass http://odoo_backend;
+    location ~* ^/web/database/ {
+        deny all;
     }
+
+    # Block test and info endpoints in production
     location ~* ^/(web/tests|website/info) {
-        # TODO: Restrict external access here
-        #    allow trusted_network;
-        #    allow trusted_ip;
-        #    deny all;
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
         deny all;
-        # proxy_pass http://odoo_backend;
     }
+
+    # Block direct RPC access from outside (use Odoo web client instead)
     location ~* ^/(jsonrpc|xmlrpc) {
-        # TODO: Restrict external access here
+        # To allow access from trusted IPs uncomment and adjust:
         #    allow trusted_network;
         #    allow trusted_ip;
         #    deny all;
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
         deny all;
-        # proxy_pass http://odoo_backend;
     }
 
     # cache some static data in memory for 60mins.
@@ -167,9 +174,6 @@ server {
         proxy_cache_valid 200 60m;
         proxy_buffering    on;
         expires 864000;
-        {% if ssl_on %}
-	    add_header Content-Security-Policy "upgrade-insecure-requests";
-        {% endif %}
         proxy_pass         http://odoo_backend;
     }
 

--- a/subpackages/lib/data/templates/deploy/nginx.conf.tmpl
+++ b/subpackages/lib/data/templates/deploy/nginx.conf.tmpl
@@ -55,9 +55,22 @@ server {
     # SSL config
     ssl_certificate     {{ config.nginx.ssl_cert }};
     ssl_certificate_key {{ config.nginx.ssl_key }};
+    {% if config.nginx.tls12_compat %}
     ssl_protocols       TLSv1.2 TLSv1.3;
-    ssl_ciphers         HIGH:!aNULL:!MD5;
+
+    # TLS 1.2 cipher suites: prefer ECDHE (Forward Secrecy), allow RSA key
+    # exchange only as fallback for backward compatibility. GCM and CHACHA20
+    # only — no CBC, RC4, 3DES or other weak/non-FIPS-140-2 ciphers.
+    # TLS 1.3 ciphers (TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384)
+    # are configured automatically by nginx and not affected by ssl_ciphers.
+    ssl_ciphers         ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:AES128-GCM-SHA256:AES256-GCM-SHA384;
     ssl_prefer_server_ciphers on;
+    {% else %}
+    ssl_protocols       TLSv1.3;
+    # TLS 1.3 cipher suites (TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384,
+    # TLS_CHACHA20_POLY1305_SHA256) are configured automatically by nginx.
+    # ssl_ciphers and ssl_prefer_server_ciphers have no effect on TLS 1.3.
+    {% endif %}
     ssl_session_cache   shared:SSL:10m;
     ssl_session_timeout 10m;
     ssl_session_tickets off;

--- a/subpackages/lib/data/templates/deploy/systemd.tmpl
+++ b/subpackages/lib/data/templates/deploy/systemd.tmpl
@@ -8,6 +8,9 @@ User={{ project.odoo.server_user }}
 Group={{ project.odoo.server_user }}
 ExecStart={{ project.server.scriptPath }} --config {{ project.odoo.configfile }}
 KillMode=mixed
+{% if !config.odoo.system_ca_bundle_path.isNull %}
+Environment="REQUESTS_CA_BUNDLE={{ config.odoo.system_ca_bundle_path.get }}"
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target

--- a/subpackages/lib/dub.sdl
+++ b/subpackages/lib/dub.sdl
@@ -9,6 +9,7 @@ dependency "dini" version="~>2.0.0"
 dependency "dyaml" version=">=0.9.2"
 
 dependency "peque" version=">=0.0.4"
+dependency "requests" version=">=2.0.0"
 dependency "darktemple" version=">=0.0.6"
 
 subConfiguration "peque" "libraryDynamic"

--- a/subpackages/lib/dub.selections.json
+++ b/subpackages/lib/dub.selections.json
@@ -5,7 +5,7 @@
 		"bindbc-common": "1.0.5",
 		"bindbc-loader": "1.1.5",
 		"cachetools": "0.4.2",
-		"darktemple": "0.0.8",
+		"darktemple": "0.0.9",
 		"dini": "2.0.0",
 		"dpq": "0.11.6",
 		"dshould": "1.8.0",

--- a/subpackages/lib/dub.selections.json
+++ b/subpackages/lib/dub.selections.json
@@ -16,7 +16,7 @@
 		"requests": "2.2.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.0.10",
+		"theprocess": "0.1.0",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.2.3",
 		"versioned": "0.1.0",

--- a/subpackages/lib/dub.selections.json
+++ b/subpackages/lib/dub.selections.json
@@ -16,7 +16,7 @@
 		"requests": "2.2.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.1.0",
+		"theprocess": "0.1.1",
 		"tinyendian": "0.2.0",
 		"unit-threaded": "2.2.3",
 		"versioned": "0.1.0",

--- a/subpackages/lib/source/odood/lib/addons/manager.d
+++ b/subpackages/lib/source/odood/lib/addons/manager.d
@@ -351,13 +351,13 @@ struct AddonManager {
         final switch(cmd) {
             case cmdIU.install:
                 infof("Installing addons (db=%s): %s", database, addon_names_csv);
-                runner.addArgs("--init=%s".format(addon_names_csv))
+                runner.withArgs("--init=%s".format(addon_names_csv))
                     .execute.ensureOk!AddonsInstallException(true);
                 infof("Installation of addons for database %s completed!", database);
                 break;
             case cmdIU.update:
                 infof("Updating addons (db=%s): %s", database, addon_names_csv);
-                runner.addArgs("--update=%s".format(addon_names_csv))
+                runner.withArgs("--update=%s".format(addon_names_csv))
                     .execute.ensureOk!AddonsUpdateException(true);
                 infof("Update of addons for database %s completed!", database);
                 break;

--- a/subpackages/lib/source/odood/lib/assembly/assembly.d
+++ b/subpackages/lib/source/odood/lib/assembly/assembly.d
@@ -11,6 +11,7 @@ private import std.array: empty, join, array, split, assocArray;
 private import std.algorithm: map, canFind, uniq, startsWith;
 private import std.range: chain;
 private import std.regex: replaceFirst, regex;
+private import std.string: strip;
 private import std.process: environment;
 private import std.datetime.date: DateTime;
 private import std.datetime.systime: Clock;
@@ -570,16 +571,18 @@ struct Assembly {
         auto assembly = this;
         // TODO: move to template, after darktemple will be ready for this
         auto handle_requirements_txt = path.join("requirements.txt").exists;
+        auto assembly_version = version_path.exists ? version_path.readFileText.strip : "";
+        auto assembly_source_url = repo.hasRemoteUrl("origin") ? repo.getRemoteUrl().toString : "";
         if (path.join("Dockerfile").exists) {
             string dockerfile_content = path.join("Dockerfile")
                 .readFileText
                 .replaceFirst(
                     regex(".*# ---- ODOOD END DYNAMIC DOCKER CONFIG ----\n", "s"),
-                    renderFile!("templates/assembly/Dockerfile.tmpl", assembly, handle_requirements_txt));
+                    renderFile!("templates/assembly/Dockerfile.tmpl", assembly, handle_requirements_txt, assembly_version, assembly_source_url));
             path.join("Dockerfile").writeFile(dockerfile_content);
         } else {
             path.join("Dockerfile").writeFile(
-                renderFile!("templates/assembly/Dockerfile.tmpl", assembly, handle_requirements_txt));
+                renderFile!("templates/assembly/Dockerfile.tmpl", assembly, handle_requirements_txt, assembly_version, assembly_source_url));
         }
         repo.add(path.join("Dockerfile"));
         infof("Assembly: Dockerfile generated/updated!");

--- a/subpackages/lib/source/odood/lib/assembly/assembly.d
+++ b/subpackages/lib/source/odood/lib/assembly/assembly.d
@@ -525,8 +525,7 @@ struct Assembly {
       *    base_rev = base revision. Changelog will be generated for changes between base_rev and current commit.
       **/
     void generateChangelog(in string base_rev) {
-        infof("Assembly: Generiating changelog.");
-        // TODO: We have also handle cases, when no origin repo connected to assembly
+        infof("Assembly: Generating changelog.");
 
         auto changes = getChanges(base_rev: base_rev);
         auto release_date = cast(DateTime)Clock.currTime();
@@ -561,9 +560,15 @@ struct Assembly {
     }
 
     void generateChangelog() {
-        // Base, that have to be used to generate changelog
-        auto base_rev = "origin/"~project.odoo.serie.toString;
-        generateChangelog(base_rev);
+        if (repo.hasRemoteUrl("origin"))
+            generateChangelog("origin/" ~ project.odoo.serie.toString);
+        else if (repo.hasLocalBranch(project.odoo.serie.toString))
+            generateChangelog(project.odoo.serie.toString);
+        else
+            throw new OdoodAssemblyException(
+                "Changelog generation requires an 'origin' remote to be configured " ~
+                "and local or remote branch named same as Odoo serie. " ~
+                "Or, base revision to compare changes to have to be provided.");
     }
 
     void generateDockerfile() {

--- a/subpackages/lib/source/odood/lib/assembly/changes.d
+++ b/subpackages/lib/source/odood/lib/assembly/changes.d
@@ -24,7 +24,7 @@ struct NotableChanges {
     string name;
     OdooStdVersion old_version;
     OdooStdVersion new_version;
-    OdooAddonChangelogEntrie[] changelog;
+    OdooAddonChangelogEntry[] changelog;
 }
 
 
@@ -63,7 +63,7 @@ class AssemblyChanges {
             in string name,
             in OdooStdVersion old_version,
             in OdooStdVersion new_version,
-            in OdooAddonChangelogEntrie[] changelog) {
+            in OdooAddonChangelogEntry[] changelog) {
         addons_updated ~= AddonUpdated(name, old_version, new_version);
         if (changelog.length > 0)
             notable_changes ~= NotableChanges(name, old_version, new_version, changelog.dup);

--- a/subpackages/lib/source/odood/lib/deploy/config.d
+++ b/subpackages/lib/source/odood/lib/deploy/config.d
@@ -26,6 +26,35 @@ private import odood.git: GitURL;
 
 immutable auto DEFAULT_PASSWORD_LEN = 32;
 
+/** Known system CA bundle paths, ordered by preference.
+  * The first path that exists on the system will be used.
+  **/
+private immutable string[] KNOWN_CA_BUNDLE_PATHS = [
+    "/etc/ssl/certs/ca-certificates.crt",       // Debian, Ubuntu, Alpine
+    "/etc/pki/tls/certs/ca-bundle.crt",          // RHEL, CentOS, Fedora
+    "/etc/ssl/ca-bundle.pem",                     // openSUSE
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",  // RHEL/CentOS (alt)
+];
+
+/** Detect system CA bundle path.
+  * Returns the first known path that exists, or null if none found.
+  **/
+Nullable!Path detectSystemCABundle() {
+    foreach (p; KNOWN_CA_BUNDLE_PATHS) {
+        auto path = Path(p);
+        if (path.exists)
+            return Nullable!Path(path);
+    }
+    return Nullable!Path.init;
+}
+
+unittest {
+    // detectSystemCABundle should return a valid path or null, never throw.
+    auto result = detectSystemCABundle();
+    // On CI (Ubuntu), the Debian path should exist.
+    // On other systems, we just verify it doesn't crash.
+}
+
 
 /** Odoo database cofiguration to be deployed
   **/
@@ -49,7 +78,8 @@ struct DeployConfigOdoo {
     uint workers=0;
 
     string server_user="odoo";
-    // TODO: Add configuration to automatically patch system config to use system ssl certificates for requests
+    bool use_system_ca_bundle = false;
+    Nullable!Path system_ca_bundle_path;
     ProjectServerSupervisor server_supervisor=ProjectServerSupervisor.Systemd;
     Path server_init_script_path = Path(
         "/", "etc", "init.d", "odoo");
@@ -182,6 +212,13 @@ struct DeployConfig {
                 this.nginx.ssl_cert.exists(),
                 "SSL enabled, but provided SSL certificate (%s) does not exists!".format(this.nginx.ssl_cert));
         }
+
+        if (this.odoo.use_system_ca_bundle)
+            enforce!OdoodDeployException(
+                !this.odoo.system_ca_bundle_path.isNull
+                    && this.odoo.system_ca_bundle_path.get.exists,
+                "Use system CA bundle requested, but no CA bundle found. " ~
+                "Install the `ca-certificates` package and try again.");
 
         if (this.letsencrypt_enable) {
             enforce!OdoodDeployException(

--- a/subpackages/lib/source/odood/lib/deploy/config.d
+++ b/subpackages/lib/source/odood/lib/deploy/config.d
@@ -98,7 +98,7 @@ struct DeployConfig {
 
     bool letsencrypt_enable = false;
     string letsencrypt_email = null;
-    Path letsencrypt_webroot = Path("/", "var", "/var/acme_challenge_webroot");
+    Path letsencrypt_webroot = Path("/", "var", "acme_challenge_webroot");
     uint letsencrypt_rsa_key_size = 4096;
 
     Nullable!GitURL assembly_repo;
@@ -128,7 +128,7 @@ struct DeployConfig {
 
         if (this.logrotate_enable)
             enforce!OdoodDeployException(
-                !Path("etc", "logrotate.d", "odoo").exists,
+                !Path("/", "etc", "logrotate.d", "odoo").exists,
                 "It seems that Odoo config for logrotate already exists!");
 
         final switch(this.odoo.server_supervisor) {

--- a/subpackages/lib/source/odood/lib/deploy/config.d
+++ b/subpackages/lib/source/odood/lib/deploy/config.d
@@ -7,7 +7,7 @@ private import std.format: format;
 private import std.typecons: Nullable;
 
 private import thepath: Path;
-private import theprocess: Process, resolveProgram;
+private import theprocess: Process, resolveProgram, systemUserExists;
 
 private import odood.lib.odoo.config: initOdooConfig;
 private import odood.lib.project:
@@ -21,7 +21,7 @@ private import odood.lib.project.config:
 private import odood.lib.deploy.exception: OdoodDeployException;
 private import odood.lib.venv: VenvOptions, PyInstallType;
 private import odood.utils.odoo.serie: OdooSerie;
-private import odood.utils: generateRandomString, checkSystemUserExists;
+private import odood.utils: generateRandomString;
 private import odood.git: GitURL;
 
 immutable auto DEFAULT_PASSWORD_LEN = 32;
@@ -154,7 +154,7 @@ struct DeployConfig {
         if (this.database.local_postgres)
             // If local postgres requested, we expect that `postgres` user exists in system.
             enforce!OdoodDeployException(
-                checkSystemUserExists("postgres"),
+                systemUserExists("postgres"),
                 "Local postgres requested, but 'postgresql' package seems not installed!");
 
         if (this.nginx.enable)

--- a/subpackages/lib/source/odood/lib/deploy/config.d
+++ b/subpackages/lib/source/odood/lib/deploy/config.d
@@ -70,6 +70,7 @@ struct DeployConfigNginx {
 
 
     bool ssl_on = false;
+    bool tls12_compat = false;
     Path ssl_cert = Path("/", "etc", "nginx", "ssl", "server.crt");
     Path ssl_key = Path("/", "etc", "nginx", "ssl", "server.key");
 

--- a/subpackages/lib/source/odood/lib/deploy/odoo.d
+++ b/subpackages/lib/source/odood/lib/deploy/odoo.d
@@ -24,13 +24,13 @@ private import odood.lib.deploy.utils:
     postgresCreateUser;
 
 
-private void deployInitScript(in Project project) {
+private void deployInitScript(in Project project, in DeployConfig config) {
 
     infof("Configuring init script for Odoo...");
 
     // Configure init scripts
     project.odoo.server_init_script_path.writeFile(
-        renderFile!("templates/deploy/init.d.tmpl", project));
+        renderFile!("templates/deploy/init.d.tmpl", project, config));
 
     // Set access rights for init script
     project.odoo.server_init_script_path.setAttributes(octal!755);
@@ -45,13 +45,13 @@ private void deployInitScript(in Project project) {
 }
 
 
-private void deploySystemdConfig(in Project project) {
+private void deploySystemdConfig(in Project project, in DeployConfig config) {
 
     infof("Configuring systemd daemon for Odoo...");
 
     // Configure systemd
     project.odoo.server_systemd_service_path.writeFile(
-        renderFile!("templates/deploy/systemd.tmpl", project));
+        renderFile!("templates/deploy/systemd.tmpl", project, config));
 
     // Set access rights for systemd config
     project.odoo.server_systemd_service_path.setAttributes(octal!755);
@@ -259,10 +259,10 @@ Project deployOdoo(in DeployConfig config) {
             // TODO: May be it have sense to create some link in /usr/sbin for Odoo?
             break;
         case ProjectServerSupervisor.InitScript:
-            deployInitScript(project);
+            deployInitScript(project, config);
             break;
         case ProjectServerSupervisor.Systemd:
-            deploySystemdConfig(project);
+            deploySystemdConfig(project, config);
             break;
     }
 

--- a/subpackages/lib/source/odood/lib/deploy/odoo.d
+++ b/subpackages/lib/source/odood/lib/deploy/odoo.d
@@ -10,11 +10,10 @@ private import std.format: format;
 private import std.string: toStringz, empty;
 
 private import thepath: Path;
-private import theprocess: Process;
+private import theprocess: Process, systemUserExists;
 private import darktemple: renderFile;
 
 private import odood.utils.odoo.serie: OdooSerie;
-private import odood.utils: checkSystemUserExists;
 private import odood.lib.project: Project, ODOOD_SYSTEM_CONFIG_PATH;
 private import odood.lib.project.config: ProjectServerSupervisor;
 
@@ -198,7 +197,7 @@ Project deployOdoo(in DeployConfig config) {
         config.install_type);
     project.save(ODOOD_SYSTEM_CONFIG_PATH);
 
-    if (!checkSystemUserExists(project.odoo.server_user))
+    if (!systemUserExists(project.odoo.server_user))
         createSystemUser(project.project_root, project.odoo.server_user);
 
     // Get info about odoo user (that is needed to set up access rights for Odoo files

--- a/subpackages/lib/source/odood/lib/deploy/odoo.d
+++ b/subpackages/lib/source/odood/lib/deploy/odoo.d
@@ -30,7 +30,7 @@ private void deployInitScript(in Project project) {
 
     // Configure init scripts
     project.odoo.server_init_script_path.writeFile(
-        renderFile!("templates/deploy/systemd.tmpl", project));
+        renderFile!("templates/deploy/init.d.tmpl", project));
 
     // Set access rights for init script
     project.odoo.server_init_script_path.setAttributes(octal!755);
@@ -162,8 +162,8 @@ private void deployFail2banConfig(in Project project, in DeployConfig config) {
     config.fail2ban_jail_path.writeFile(
         renderFile!("templates/deploy/fail2ban.jail.tmpl", project));
 
-    // Set access rights for logrotate config
-    config.fail2ban_filter_path.setAttributes(octal!644);
+    // Set access rights for jail config
+    config.fail2ban_jail_path.setAttributes(octal!644);
     config.fail2ban_jail_path.chown("root", "root");
 
     // Reload nginx

--- a/subpackages/lib/source/odood/lib/deploy/utils.d
+++ b/subpackages/lib/source/odood/lib/deploy/utils.d
@@ -34,7 +34,7 @@ void createSystemUser(in Path home, in string name) {
 bool postgresCheckUserExists(in string username) {
     // TODO: Use peque for this?
     auto output = Process("psql")
-        .setArgs([
+        .withArgs([
             "-t", "-A", "-c",
             i"SELECT count(*) FROM pg_user WHERE usename = '$(username)';".text,
         ])
@@ -69,7 +69,7 @@ void postgresCreateUser(in string username, in string password) {
     // TODO: Use peque for this?
     infof("Creating postgresql user '%s' for Odoo...", username);
     Process("psql")
-        .setArgs([
+        .withArgs([
             "-c",
             i"CREATE USER \"$(username)\" WITH CREATEDB PASSWORD '$(password)'".text,
         ])

--- a/subpackages/lib/source/odood/lib/devtools/migrate.d
+++ b/subpackages/lib/source/odood/lib/devtools/migrate.d
@@ -27,7 +27,7 @@ void migrateAddonsCode(in Project project, in AddonRepository repo, in string[] 
             infof("Migrating module %s (%s) to serie %s", addon.name, addon.manifest.module_version, project.odoo.serie);
             auto old_serie = addon.manifest.module_version.serie;
             auto cmd = project.venv.runner
-                .addArgs(
+                .withArgs(
                     "odoo-module-migrate",
                     "--directory=%s".format(addon.path.parent),
                     "--modules=%s".format(addon.name),

--- a/subpackages/lib/source/odood/lib/odoo/config.d
+++ b/subpackages/lib/source/odood/lib/odoo/config.d
@@ -143,19 +143,20 @@ string getConfVal(Ini config, in string key, return in string defValue=null) {
 
 
 /** Parse Odoo's database config and return tuple with following fields:
-  * host, port, user, password
+  * host, port, user, password, sslmode
   **/
 auto parseOdooDatabaseConfig(in Project project) {
     // TODO: handle test config
     auto config = project.readOdooConfig;
 
-
     return Tuple!(
-        string, "host", string, "port", string, "user", string, "password"
+        string, "host", string, "port", string, "user", string, "password",
+        string, "sslmode"
     )(
         config.getConfVal("db_host"),
         config.getConfVal("db_port"),
         config.getConfVal("db_user"),
         config.getConfVal("db_password"),
+        config.getConfVal("db_sslmode"),
     );
 }

--- a/subpackages/lib/source/odood/lib/odoo/config.d
+++ b/subpackages/lib/source/odood/lib/odoo/config.d
@@ -142,6 +142,46 @@ string getConfVal(Ini config, in string key, return in string defValue=null) {
 }
 
 
+/// Test getConfVal with various value types
+unittest {
+    import unit_threaded.assertions;
+
+    Ini config;
+    IniSection options = IniSection("options");
+    config.addSection(options);
+
+    config["options"].setKey("db_host", "localhost");
+    config["options"].setKey("db_port", "5432");
+    config["options"].setKey("db_password", "None");
+    config["options"].setKey("db_sslmode", "False");
+    config["options"].setKey("db_user", "false");
+    config["options"].setKey("db_none_upper", "NONE");
+
+    // Normal values are returned as-is
+    config.getConfVal("db_host").shouldEqual("localhost");
+    config.getConfVal("db_port").shouldEqual("5432");
+
+    // "None" returns default value (null by default)
+    config.getConfVal("db_password").shouldBeNull;
+    config.getConfVal("db_password", "secret").shouldEqual("secret");
+
+    // "False" returns default value (case-insensitive)
+    config.getConfVal("db_sslmode").shouldBeNull;
+    config.getConfVal("db_sslmode", "prefer").shouldEqual("prefer");
+
+    // "false" (lowercase) also returns default
+    config.getConfVal("db_user").shouldBeNull;
+    config.getConfVal("db_user", "odoo").shouldEqual("odoo");
+
+    // "NONE" (uppercase) also returns default
+    config.getConfVal("db_none_upper").shouldBeNull;
+
+    // Missing key defaults to "None" internally, so returns default
+    config.getConfVal("nonexistent_key").shouldBeNull;
+    config.getConfVal("nonexistent_key", "fallback").shouldEqual("fallback");
+}
+
+
 /** Parse Odoo's database config and return tuple with following fields:
   * host, port, user, password, sslmode
   **/

--- a/subpackages/lib/source/odood/lib/odoo/db.d
+++ b/subpackages/lib/source/odood/lib/odoo/db.d
@@ -9,6 +9,7 @@ private import thepath: Path;
 private import peque: Connection;
 
 private import odood.lib.odoo.config;
+private import odood.lib.odoo.db_utils: openPgConnection;
 private import odood.lib.project: Project;
 private import odood.utils.addons.addon: OdooAddon;
 private import odood.exception: OdoodException;
@@ -26,21 +27,7 @@ package(odood.lib) struct OdooDatabase {
         _project = project;
         _dbname = dbname;
 
-        auto db_conf = _project.parseOdooDatabaseConfig;
-
-        string[string] db_params = [
-            "dbname": dbname,
-        ];
-        if (db_conf.host)
-            db_params["host"] = db_conf.host;
-        if (db_conf.port)
-            db_params["port"] = db_conf.port;
-        if (db_conf.user)
-            db_params["user"] = db_conf.user;
-        if (db_conf.password)
-            db_params["password"] = db_conf.password;
-
-        _connection = Connection(db_params);
+        _connection = _project.openPgConnection(dbname);
     }
 
     /** Return dpq connection to database

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -315,7 +315,7 @@ struct OdooDatabaseManager {
         import std.uni;
         import peque.exception;
         import odood.lib.odoo.config: getConfVal;
-        auto odoo_conf = _project.getOdooConfig();
+        auto odoo_conf = _project.server.getConfig;
         auto db_template = odoo_conf.getConfVal("db_template", "template0");
         auto collate = (db_template == "template0") ? "LC_COLLATE 'C'" : "";
 

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -4,20 +4,22 @@
 module odood.lib.odoo.db_manager;
 
 private import std.logger;
+private import std.array: array;
 private import std.json;
 private import std.format: format;
 private import std.exception: enforce;
 private import std.typecons;
 private import std.datetime.systime: Clock;
+private import std.algorithm.iteration: filter, map;
 private import std.algorithm.searching: canFind;
-private import std.string: join, startsWith, chompPrefix, empty;
+private import std.string: join, startsWith, chompPrefix, empty, split, strip;
 
 private import thepath;
 private import theprocess;
 private import zipper;
 
 private import odood.lib.project: Project;
-private import odood.lib.odoo.config: parseOdooDatabaseConfig;
+private import odood.lib.odoo.config: parseOdooDatabaseConfig, getConfVal;
 private import odood.lib.odoo.db: OdooDatabase;
 private import odood.lib.odoo.db_utils: openPgConnection;
 
@@ -45,10 +47,52 @@ struct OdooDatabaseManager {
         _test_mode = test_mode;
     }
 
-    /** Return list of databases available on this odoo instance
+    /** Return list of databases available on this odoo instance.
+      *
+      * Mirrors Odoo's own list_dbs() logic:
+      *
+      * - If db_name is set in odoo.conf, return those names directly without
+      *   querying PostgreSQL.
+      * - Otherwise, query pg_database restricted to databases owned by the
+      *   current PostgreSQL user (datdba = current_user).
+      *
+      * db_filter is intentionally ignored: it is HTTP-specific (used to select
+      * a database based on request hostname).
       **/
     string[] list() const {
-        return _project.lodoo(_test_mode).databaseList();
+        import std.algorithm.sorting: sort;
+
+        auto odoo_conf = _project.server.getConfig;
+
+        // If db_name is configured, use it directly — no PG query needed.
+        auto db_name_conf = odoo_conf.getConfVal("db_name");
+        if (db_name_conf) {
+            auto result = db_name_conf.split(",").map!(s => s.strip).array;
+            result.sort();
+            return result;
+        }
+
+        // Query pg_database scoped to databases owned by the current PG user.
+        auto db_template = odoo_conf.getConfVal("db_template", "template0");
+        auto conn = _project.openPgConnection("postgres");
+        auto res = conn.transaction((ref tx) {
+            return tx.execParams(
+                "SELECT datname FROM pg_database " ~
+                "WHERE datdba = (SELECT usesysid FROM pg_user WHERE usename = current_user) " ~
+                "  AND NOT datistemplate " ~
+                "  AND datallowconn " ~
+                "  AND datname != $1 " ~
+                "  AND datname != $2 " ~
+                "ORDER BY datname",
+                "postgres",
+                db_template
+            );
+        });
+
+        string[] databases;
+        foreach (row; res)
+            databases ~= row[0].as!string;
+        return databases;
     }
 
     /** Create new Odoo database on this odoo instance

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -164,8 +164,8 @@ struct OdooDatabaseManager {
                 scope(exit) tmp_dir.remove();
 
                 // Run database backup
+                pg_dump.addArgs("--file=" ~ tmp_dir.join("dump.sql").toString);
                 auto dump_pid = pg_dump
-                    .addArgs("--file=" ~ tmp_dir.join("dump.sql").toString)
                     .spawn(
                         std.stdio.File("/dev/null"),
                         tmp_dir.join("pg_dump.output.log").openFile("wt"),
@@ -196,7 +196,7 @@ struct OdooDatabaseManager {
             case BackupFormat.sql:
                 // In case of SQL backups, just call pg_dump and let it do its job.
                 pg_dump
-                    .addArgs(
+                    .withArgs(
                         "--format=c",
                         "--file=" ~ dest.toString)
                     .execute
@@ -498,7 +498,7 @@ struct OdooDatabaseManager {
             "Running 'populate' for database %s for models (%s) with size %s...",
             dbname, models.join(", "), populate_size);
         _project.server(_test_mode).getServerRunner("populate")
-            .addArgs(
+            .withArgs(
                 "-d", dbname,
                 "--models=%s".format(models.join(",")),
                 "--size=%s".format(populate_size),

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -19,6 +19,8 @@ private import zipper;
 private import odood.lib.project: Project;
 private import odood.lib.odoo.config: parseOdooDatabaseConfig;
 private import odood.lib.odoo.db: OdooDatabase;
+private import odood.lib.odoo.db_utils: openPgConnection;
+
 private import odood.utils.odoo: parseServerSerie;
 private import odood.utils.odoo.serie: OdooSerie;
 private import odood.utils.odoo.db: detectDatabaseBackupFormat, BackupFormat;
@@ -66,11 +68,15 @@ struct OdooDatabaseManager {
     /** Check if database exists
       **/
     bool exists(in string name) const {
-        // TODO: replace with project's db wrapper to check if database exists
-        //       This could improve performance by avoiding call to python
-        //       interpreter. Take into account that database could exist,
-        //       but still could not be visible for Odoo.
-        return _project.lodoo(_test_mode).databaseExists(name);
+        auto conn = _project.openPgConnection("postgres");
+        auto res = conn.transaction((ref tx) {
+            return tx.execParams(
+                "SELECT EXISTS (" ~
+                "    SELECT 1 FROM pg_catalog.pg_database WHERE datname = $1" ~
+                ")",
+                name);
+        });
+        return res[0][0].get!bool;
     }
 
     /** Rename database
@@ -319,7 +325,7 @@ struct OdooDatabaseManager {
         auto db_template = odoo_conf.getConfVal("db_template", "template0");
         auto collate = (db_template == "template0") ? "LC_COLLATE 'C'" : "";
 
-        auto pg_db = this.get("postgres").connection;
+        auto pg_db = _project.openPgConnection("postgres");
         pg_db.exec(
             "CREATE DATABASE \"%s\" ENCODING 'unicode' %s TEMPLATE %s".format(
                 name, collate, db_template));

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -158,6 +158,52 @@ struct OdooDatabaseManager {
         return _project.lodoo(_test_mode).databaseCopy(old_name, new_name);
     }
 
+    /** Ensure database is initialized as an Odoo database.
+      *
+      * Idempotent: safe to call on every deploy.
+      * - If the PG database does not exist, creates it.
+      * - If the database is not Odoo-initialized, runs Odoo with
+      *   --init=base --stop-after-init to initialize it.
+      * - If the database is already initialized, does nothing.
+      *
+      * Params:
+      *     name = database name
+      *     demo = load demo data (only effective on first initialization)
+      *     lang = language code, e.g. "en_US" (only effective on first initialization)
+      **/
+    void ensureInitialized(
+            in string name,
+            in bool demo = false,
+            in string lang = null) const {
+        if (!exists(name)) {
+            infof("Database '%s' does not exist. Creating...", name);
+            _createEmptyDB(name);
+        }
+
+        if (!isInitialized(name)) {
+            infof("Initializing Odoo database '%s'...", name);
+            auto swm = _project.server.getConfig.getConfVal(
+                "server_wide_modules", "base,web");
+            auto runner = _project.server(_test_mode).getServerRunner(
+                "-d", name,
+                "--max-cron-threads=0",
+                "--stop-after-init",
+                _project.odoo.serie <= OdooSerie(10) ? "--no-xmlrpc" : "--no-http",
+                "--pidfile=",
+                "--logfile=%s".format(_project.odoo.logfile),
+                "--init=%s".format(swm),
+            );
+            if (!demo)
+                runner.addArgs("--without-demo=all");
+            if (lang)
+                runner.addArgs("--lang=%s".format(lang));
+            runner.execute.ensureOk!OdoodException(true);
+            infof("Database '%s' initialized.", name);
+        } else {
+            infof("Database '%s' is already initialized.", name);
+        }
+    }
+
     /** Generate name of backup
       **/
     private string generateBackupName(

--- a/subpackages/lib/source/odood/lib/odoo/db_manager.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_manager.d
@@ -79,6 +79,29 @@ struct OdooDatabaseManager {
         return res[0][0].get!bool;
     }
 
+    /** Check if database is initialized as an Odoo database.
+      *
+      * Checks for the presence of the ir_module_module table, which is
+      * created during Odoo's database initialization.
+      *
+      * Returns:
+      *     true if the database contains an Odoo installation, false otherwise.
+      **/
+    bool isInitialized(in string name) const {
+        auto conn = _project.openPgConnection(name);
+        auto res = conn.transaction((ref tx) {
+            tx.exec("SET LOCAL lock_timeout = '15s'");
+            return tx.execParams(
+                "SELECT EXISTS (" ~
+                "    SELECT 1 FROM information_schema.tables" ~
+                "    WHERE table_name = 'ir_module_module'" ~
+                "    AND table_schema = 'public'" ~
+                ")"
+            );
+        });
+        return res[0][0].get!bool;
+    }
+
     /** Rename database
       **/
     auto rename(in string old_name, in string new_name) const {

--- a/subpackages/lib/source/odood/lib/odoo/db_utils.d
+++ b/subpackages/lib/source/odood/lib/odoo/db_utils.d
@@ -1,0 +1,34 @@
+/// Database utility functions
+module odood.lib.odoo.db_utils;
+
+private import peque: Connection;
+
+private import odood.lib.project: Project;
+private import odood.lib.odoo.config: parseOdooDatabaseConfig;
+
+
+/** Open a peque connection to a PostgreSQL database using the connection
+  * parameters from Odoo's configuration file.
+  *
+  * Params:
+  *     project = the Odoo project whose odoo.conf is read for DB params
+  *     dbname  = name of the database to connect to (default: "postgres")
+  *
+  * Returns:
+  *     An open peque Connection.
+  **/
+package(odood.lib) Connection openPgConnection(in Project project, in string dbname) {
+    auto db_conf = project.parseOdooDatabaseConfig;
+    string[string] params = ["dbname": dbname];
+    if (db_conf.host)
+        params["host"] = db_conf.host;
+    if (db_conf.port)
+        params["port"] = db_conf.port;
+    if (db_conf.user)
+        params["user"] = db_conf.user;
+    if (db_conf.password)
+        params["password"] = db_conf.password;
+    if (db_conf.sslmode)
+        params["sslmode"] = db_conf.sslmode;
+    return Connection(params);
+}

--- a/subpackages/lib/source/odood/lib/odoo/lodoo.d
+++ b/subpackages/lib/source/odood/lib/odoo/lodoo.d
@@ -47,7 +47,7 @@ const struct LOdoo {
 
         auto runner() const {
             auto process = _project.venv.runner()
-                .addArgs("lodoo", "--conf", odoo_conf_path.toString);
+                .withArgs("lodoo", "--conf", odoo_conf_path.toString);
             if (_project.odoo.server_user)
                 process.setUser(_project.odoo.server_user);
             return process;
@@ -57,7 +57,7 @@ const struct LOdoo {
           **/
         string[] databaseList() {
             return runner
-                .addArgs("db-list")
+                .withArgs("db-list")
                 .withFlag(Config.stderrPassThrough)
                 .execute()
                 .ensureOk!OdoodException(true)
@@ -69,7 +69,7 @@ const struct LOdoo {
         void databaseCreate(in string name, in bool demo=false,
                             in string lang=null, in string password=null,
                             in string country=null) {
-            auto cmd = runner.addArgs(
+            auto cmd = runner.withArgs(
                 "db-create",
                 demo ? "--demo" : "--no-demo",
             );
@@ -96,7 +96,7 @@ const struct LOdoo {
         void databaseDrop(in string name) {
             infof("Deleting database %s", name);
             runner
-                .addArgs("db-drop", name)
+                .withArgs("db-drop", name)
                 .execute
                 .ensureOk!OdoodException(true);
         }
@@ -105,7 +105,7 @@ const struct LOdoo {
           **/
         bool databaseExists(in string name) {
             return runner
-                .addArgs("db-exists", name)
+                .withArgs("db-exists", name)
                 .execute()
                 .status == 0;
         }
@@ -115,7 +115,7 @@ const struct LOdoo {
         void databaseRename(in string old_name, in string new_name) {
             infof("Renaming database %s to %s", old_name, new_name);
             runner
-                .addArgs("db-rename", old_name, new_name)
+                .withArgs("db-rename", old_name, new_name)
                 .execute
                 .ensureOk!OdoodException(true);
         }
@@ -125,7 +125,7 @@ const struct LOdoo {
         auto databaseCopy(in string old_name, in string new_name) {
             infof("Copying database %s to %s", old_name, new_name);
             runner
-                .addArgs("db-copy", old_name, new_name)
+                .withArgs("db-copy", old_name, new_name)
                 .execute
                 .ensureOk!OdoodException(true);
         }
@@ -135,7 +135,7 @@ const struct LOdoo {
         deprecated void databaseRestore(in string name, in Path backup_path) {
             infof("Restoring database %s from %s", name, backup_path);
             runner
-                .addArgs("db-restore", name, backup_path.toString)
+                .withArgs("db-restore", name, backup_path.toString)
                 .execute
                 .ensureOk!OdoodException(true);
 
@@ -143,7 +143,7 @@ const struct LOdoo {
 
         auto databaseDumpManifest(in string name) {
             return runner
-                .addArgs("db-dump-manifest", name)
+                .withArgs("db-dump-manifest", name)
                 .withFlag(Config.stderrPassThrough)
                 .execute
                 .ensureOk!OdoodException(true)
@@ -161,7 +161,7 @@ const struct LOdoo {
           **/
         void addonsUpdateList(in string dbname, in bool ignore_error=false) {
             auto res = runner
-                .addArgs("addons-update-list", dbname)
+                .withArgs("addons-update-list", dbname)
                 .execute;
             if (!ignore_error)
                 res.ensureOk!OdoodException(true);
@@ -171,7 +171,7 @@ const struct LOdoo {
           **/
         void addonsUninstall(in string dbname, in string[] addon_names) {
             runner
-                .addArgs("addons-uninstall", dbname, addon_names.join(","))
+                .withArgs("addons-uninstall", dbname, addon_names.join(","))
                 .execute
                 .ensureOk!OdoodException(true);
         }
@@ -190,7 +190,7 @@ const struct LOdoo {
             auto sw = StopWatch(AutoStart.yes);
 
             // NOTE: This way, script will print on standard stderr/stdout
-            auto pid = runner.addArgs("run-py-script", dbname, script_path.toString)
+            auto pid = runner.withArgs("run-py-script", dbname, script_path.toString)
                 .spawn;
             // TODO: Find a way to capture script output. Do we need output?
             auto result = pid.wait;
@@ -208,8 +208,8 @@ const struct LOdoo {
         void recomputeField(in string dbname, in string model, in string[] fields) const {
             import std.algorithm.iteration;
             this.runner
-                .addArgs("odoo-recompute", dbname, model)
-                .addArgs(fields.map!(f => ["-f", f]).fold!((a, b) => a ~ b).array)
+                .withArgs("odoo-recompute", dbname, model)
+                .withArgs(fields.map!(f => ["-f", f]).fold!((a, b) => a ~ b).array)
                 .execute
                 .ensureOk!OdoodException(true);
         }
@@ -217,7 +217,7 @@ const struct LOdoo {
         void generatePot(in string dbname, in string addon, in bool remove_dates=false) const {
             infof("Generating POT file for %s database for %s addon", dbname, addon);
             auto runner = this.runner
-                .addArgs("tr-generate-pot-file");
+                .withArgs("tr-generate-pot-file");
             if (remove_dates)
                 runner.addArgs("--remove-dates");
             runner.addArgs(dbname, addon);

--- a/subpackages/lib/source/odood/lib/odoo/log.d
+++ b/subpackages/lib/source/odood/lib/odoo/log.d
@@ -178,6 +178,58 @@ immutable auto RE_LOG_RECORD_DATA = ctRegex!(
 }
 
 
+/// Test OdooLogRecord.isError
+unittest {
+    import unit_threaded.assertions;
+
+    OdooLogRecord rec;
+
+    rec.log_level = "ERROR";
+    rec.isError.shouldBeTrue;
+
+    rec.log_level = "CRITICAL";
+    rec.isError.shouldBeTrue;
+
+    rec.log_level = "WARNING";
+    rec.isError.shouldBeFalse;
+
+    rec.log_level = "INFO";
+    rec.isError.shouldBeFalse;
+
+    rec.log_level = "DEBUG";
+    rec.isError.shouldBeFalse;
+}
+
+/// Test OdooLogRecord.toString truncation
+unittest {
+    import std.range: repeat;
+    import std.conv: to;
+    import unit_threaded.assertions;
+
+    OdooLogRecord rec;
+    rec.date = "2025-01-01 12:00:00,000";
+    rec.process_id = 12345;
+    rec.log_level = "INFO";
+    rec.db = "mydb";
+    rec.logger = "odoo.test";
+
+    // Short message: not truncated
+    rec.msg = "short message";
+    auto str = rec.toString;
+    str.shouldEqual("2025-01-01 12:00:00,000 12345 INFO mydb odoo.test short message");
+
+    // Long message (>200 chars): truncated with "..."
+    rec.msg = 'x'.repeat(250).to!string;
+    auto long_str = rec.toString;
+    import std.algorithm.searching: canFind;
+    long_str.canFind("...").shouldBeTrue;
+    // The truncated message portion should be 200 chars + "..."
+    import std.string: indexOf;
+    auto x_run_start = long_str.indexOf('x');
+    auto suffix = long_str[x_run_start .. $];
+    suffix.shouldEqual('x'.repeat(200).to!string ~ "...");
+}
+
 ///
 unittest {
     import unit_threaded.assertions;

--- a/subpackages/lib/source/odood/lib/odoo/test.d
+++ b/subpackages/lib/source/odood/lib/odoo/test.d
@@ -49,7 +49,6 @@ string generateTestDbName(in Project project) {
 private immutable auto RE_ERROR_CHECKS = [
     ctRegex!(`At least one test failed`),
     ctRegex!(`invalid module names, ignored`),
-    ctRegex!(`no access rules.*, consider adding`),
     ctRegex!(`OperationalError: FATAL`),
     ctRegex!(`Comparing apples and oranges`),
     ctRegex!(`Module .+ demo data failed to install, installed without demo data`),
@@ -88,12 +87,6 @@ unittest {
 
     // Pattern: "invalid module names, ignored"
     is_re_error("invalid module names, ignored: nonexistent_module ").shouldBeTrue;
-
-    // Pattern: "no access rules, consider adding one"
-    // Older versions (example 12.0)
-    is_re_error("The model res.custom has no access rules, consider adding one. E.g. access_res_custom,access_res_custom,model_res_custom,base.group_user,1,0,0,0 ").shouldBeTrue;
-    // Newer version (example 15.0)
-    is_re_error("The models ['res.custom'] have no access rules in module my_module, consider adding some").shouldBeTrue;
 
     // Pattern: "OperationalError: FATAL"
     is_re_error("OperationalError: FATAL:  password authentication failed for user \"odoo\" ").shouldBeTrue;
@@ -175,7 +168,6 @@ unittest {
     ).shouldBeTrue;
 
     // Non-matching warnings should not be filtered
-    is_safe_warning("no access rules, consider adding one ").shouldBeFalse;
     is_safe_warning("At least one test failed ").shouldBeFalse;
     is_safe_warning("").shouldBeFalse;
 }

--- a/subpackages/lib/source/odood/lib/odoo/test.d
+++ b/subpackages/lib/source/odood/lib/odoo/test.d
@@ -49,21 +49,29 @@ string generateTestDbName(in Project project) {
 private immutable auto RE_ERROR_CHECKS = [
     ctRegex!(`At least one test failed`),
     ctRegex!(`invalid module names, ignored`),
-    ctRegex!(`no access rules, consider adding one`),
+    ctRegex!(`no access rules.*, consider adding`),
     ctRegex!(`OperationalError: FATAL`),
     ctRegex!(`Comparing apples and oranges`),
-    ctRegex!(`Module [a-zA-Z0-9_]\+ demo data failed to install, installed without demo data`),
-    ctRegex!(`[a-zA-Z0-9\\._]\+.create() includes unknown fields`),
-    ctRegex!(`[a-zA-Z0-9\\._]\+.write() includes unknown fields`),
-    ctRegex!(`The group [a-zA-Z0-9\\._]\+ defined in view [a-zA-Z0-9\\._]\+ [a-z]\+ does not exist!`),
-    ctRegex!(`[a-zA-Z0-9\\._]\+: inconsistent 'compute_sudo' for computed fields`),
     ctRegex!(`Module .+ demo data failed to install, installed without demo data`),
+    ctRegex!(`[a-zA-Z0-9\\._]+\.create\(\) includes unknown fields`),
+    ctRegex!(`[a-zA-Z0-9\\._]+\.write\(\) includes unknown fields`),
+    ctRegex!(`[a-zA-Z0-9\\._]+\.create\(\) with unknown fields`),
+    ctRegex!(`[a-zA-Z0-9\\._]+\.write\(\) with unknown fields`),
+    ctRegex!(`The group [a-zA-Z0-9\\._]+ defined in view [a-zA-Z0-9\\._]+ [a-z]+ does not exist!?`),
+    ctRegex!(`The group [“'”"][a-zA-Z0-9\\._]+[“'”"] defined in view does not exist!?`),
+    ctRegex!(`[a-zA-Z0-9\\._]+: inconsistent 'compute_sudo' for computed fields`),
     ctRegex!(`Field [a-zA-Z0-9\\._]+ with unknown comodel_name '[a-zA-Z0-9\\._]+'`),
-    ctRegex!(`odoo.modules.graph: module [a-zA-Z0-9\\._]+: Unmet dependencies: [a-zA-Z0-9\\._,\s]+`),
+    ctRegex!(`module [a-zA-Z0-9\\._]+: Unmet dependencies: [a-zA-Z0-9\\._,\s]+`),
 ];
 
 unittest {
     import unit_threaded.assertions;
+
+    // RE_ERROR_CHECKS are matched against OdooLogRecord.msg — the message
+    // portion extracted from log lines like:
+    //   2023-01-02 15:34:26,873 115109 WARNING mydb odoo.modules.loading: <msg>
+    // The test inputs below use realistic msg values as they would appear
+    // after log parsing.
 
     bool is_re_error(in string msg) {
         foreach(check; RE_ERROR_CHECKS)
@@ -72,13 +80,197 @@ unittest {
         return false;
     }
 
-    is_re_error("Field my_field with unknown comodel_name 'my.model'").shouldBeTrue;
+    // Test each RE_ERROR_CHECKS pattern individually
+
+    // Pattern: "At least one test failed"
+    is_re_error("At least one test failed when loading modules").shouldBeTrue;
+    is_re_error("At least one test failed").shouldBeTrue;
+
+    // Pattern: "invalid module names, ignored"
+    is_re_error("invalid module names, ignored: nonexistent_module ").shouldBeTrue;
+
+    // Pattern: "no access rules, consider adding one"
+    // Older versions (example 12.0)
+    is_re_error("The model res.custom has no access rules, consider adding one. E.g. access_res_custom,access_res_custom,model_res_custom,base.group_user,1,0,0,0 ").shouldBeTrue;
+    // Newer version (example 15.0)
+    is_re_error("The models ['res.custom'] have no access rules in module my_module, consider adding some").shouldBeTrue;
+
+    // Pattern: "OperationalError: FATAL"
+    is_re_error("OperationalError: FATAL:  password authentication failed for user \"odoo\" ").shouldBeTrue;
+    is_re_error("OperationalError: FATAL:  database \"nonexistent\" does not exist ").shouldBeTrue;
+
+    // Pattern: "Comparing apples and oranges"
+    is_re_error("Comparing apples and oranges: res.partner(1,) and 'Administrator' ").shouldBeTrue;
+
+    // Pattern: "Module .+ demo data failed to install, installed without demo data"
+    is_re_error("Module sale demo data failed to install, installed without demo data ").shouldBeTrue;
+    is_re_error("Module generic_request_service demo data failed to install, installed without demo data ").shouldBeTrue;
+
+    // Pattern: ".create() includes unknown fields"
+    is_re_error("The model 'res.partner' does not exist. res.partner.create() includes unknown fields: custom_field ").shouldBeTrue;
+    is_re_error("sale.order.line.create() includes unknown fields: nonexistent_field ").shouldBeTrue;
+    is_re_error("sale.order.line.create() with unknown fields: nonexistent_field ").shouldBeTrue;
+
+    // Pattern: ".write() includes unknown fields"
+    is_re_error("res.partner.write() includes unknown fields: missing_field ").shouldBeTrue;
+    is_re_error("account.move.line.write() includes unknown fields: bad_column ").shouldBeTrue;
+    is_re_error("sale.order.line.write() with unknown fields: nonexistent_field ").shouldBeTrue;
+
+    // Pattern: "The group X defined in view Y ... does not exist!"
+    is_re_error("The group base.group_erp_manager defined in view sale.view_order_form edit does not exist!").shouldBeTrue;
+    is_re_error("The group sale.group_sale_manager defined in view account.view_move_form invisible does not exist!").shouldBeTrue;
+    is_re_error("The group “my_group” defined in view does not exist").shouldBeTrue;
+    is_re_error("The group 'my_group' defined in view does not exist").shouldBeTrue;
+
+    // Pattern: "inconsistent 'compute_sudo' for computed fields"
+    is_re_error("sale.order: inconsistent 'compute_sudo' for computed fields: amount_total, amount_untaxed ").shouldBeTrue;
+    is_re_error("res.partner: inconsistent 'compute_sudo' for computed fields: display_name ").shouldBeTrue;
+
+    // Pattern: "Field X with unknown comodel_name 'Y'"
+    is_re_error("Field sale.order.custom_partner_id with unknown comodel_name 'res.custom.partner' ").shouldBeTrue;
+    is_re_error("Field generic_request.request.service_id with unknown comodel_name 'generic.service' ").shouldBeTrue;
+
+    // Pattern: "module X: Unmet dependencies: Y"
     is_re_error(
-        "2025-08-26 14:56:11,130 501772 INFO odoo18-test odoo.modules.graph: module my_module: Unmet dependencies: other_module"
+        "module my_module: Unmet dependencies: another_module"
     ).shouldBeTrue;
     is_re_error(
-        "2025-08-26 14:56:11,130 501772 INFO odoo18-test odoo.modules.graph: module my_module: Unmet dependencies: other_module, another_mod"
+        "module my_module: Unmet dependencies: another_module, other_module"
     ).shouldBeTrue;
+
+    // Negative cases: normal operational messages that should NOT match
+    is_re_error("Odoo version 16.0 ").shouldBeFalse;
+    is_re_error("skip sending email in test mode ").shouldBeFalse;
+    is_re_error("Starting TestRequestBase.test_request_can_change_category ... ").shouldBeFalse;
+    is_re_error("loading 38 modules... ").shouldBeFalse;
+    is_re_error("Module sale loaded in 0.42s, 12 queries ").shouldBeFalse;
+    is_re_error("").shouldBeFalse;
+}
+
+/// Test RE_SAFE_WARNINGS patterns with realistic log messages
+unittest {
+    import unit_threaded.assertions;
+
+    bool is_safe_warning(in string msg) {
+        foreach(check; RE_SAFE_WARNINGS)
+           if (msg.matchFirst(check))
+               return true;
+        return false;
+    }
+
+    // Pattern: "Two fields (X) of Y() have the same label"
+    // Based on real log: odoo.test.2.log line 16-17
+    is_safe_warning(
+        "Two fields (date_closed, closed) of request.request() have the same label: Closed. "
+    ).shouldBeTrue;
+    is_safe_warning(
+        "Two fields (create_uid, created_by_id) of request.request() have the same label: Created by. "
+    ).shouldBeTrue;
+
+    // Pattern: "Field X: unknown parameter 'tracking'..."
+    is_safe_warning(
+        "Field generic_request.request.date_deadline: unknown parameter 'tracking', " ~
+        "if this is an actual parameter you may want to override the " ~
+        "method _valid_field_parameter on the relevant model in order to allow it"
+    ).shouldBeTrue;
+
+    // Non-matching warnings should not be filtered
+    is_safe_warning("no access rules, consider adding one ").shouldBeFalse;
+    is_safe_warning("At least one test failed ").shouldBeFalse;
+    is_safe_warning("").shouldBeFalse;
+}
+
+/// Test OdooTestResult state management
+unittest {
+    import unit_threaded.assertions;
+
+    // Test initial state
+    OdooTestResult result;
+    result.success.shouldBeFalse;
+    result.cancelled.shouldBeFalse;
+    result.cancelReason.shouldBeNull;
+    result.logRecords.length.shouldEqual(0);
+
+    // Test setSuccess
+    result.setSuccess();
+    result.success.shouldBeTrue;
+    result.cancelled.shouldBeFalse;
+
+    // Test setFailed
+    result.setFailed();
+    result.success.shouldBeFalse;
+    result.cancelled.shouldBeFalse;
+
+    // Test setCancelled sets both cancelled and failed
+    result.setSuccess();  // reset to success first
+    result.success.shouldBeTrue;
+    result.setCancelled("Keyboard interrupt");
+    result.success.shouldBeFalse;
+    result.cancelled.shouldBeTrue;
+    result.cancelReason.shouldEqual("Keyboard interrupt");
+}
+
+/// Test OdooTestResult log record filtering (warnings/errors)
+unittest {
+    import std.algorithm: map;
+    import std.array: array;
+    import unit_threaded.assertions;
+
+    OdooTestResult result;
+
+    // Add various log records
+    OdooLogRecord info_rec;
+    info_rec.log_level = "INFO";
+    info_rec.msg = "Normal info message";
+    result.addLogRecord(info_rec);
+
+    OdooLogRecord warn_rec;
+    warn_rec.log_level = "WARNING";
+    warn_rec.msg = "Some warning";
+    result.addLogRecord(warn_rec);
+
+    OdooLogRecord err_rec;
+    err_rec.log_level = "ERROR";
+    err_rec.msg = "Something failed";
+    result.addLogRecord(err_rec);
+
+    OdooLogRecord crit_rec;
+    crit_rec.log_level = "CRITICAL";
+    crit_rec.msg = "Critical failure";
+    result.addLogRecord(crit_rec);
+
+    // A WARNING that matches RE_ERROR_CHECKS (treated as error)
+    OdooLogRecord warn_error_rec;
+    warn_error_rec.log_level = "WARNING";
+    warn_error_rec.msg = "At least one test failed";
+    result.addLogRecord(warn_error_rec);
+
+    result.logRecords.length.shouldEqual(5);
+
+    // warnings() should return only WARNING-level records
+    auto warnings = result.warnings.array;
+    warnings.length.shouldEqual(2);
+    warnings[0].msg.shouldEqual("Some warning");
+    warnings[1].msg.shouldEqual("At least one test failed");
+
+    // errors() should return ERROR, CRITICAL, and WARNING matching RE_ERROR_CHECKS
+    auto errors = result.errors.array;
+    errors.length.shouldEqual(3);
+    errors.map!(e => e.msg).array.shouldEqual(
+        ["Something failed", "Critical failure", "At least one test failed"]);
+}
+
+/// Test OdooTestResult duration tracking
+unittest {
+    import core.time: seconds;
+    import unit_threaded.assertions;
+
+    OdooTestResult result;
+    result.setDurationTotal(5.seconds);
+    result.setDurationTests(3.seconds);
+
+    result.totalDuration.shouldEqual(5.seconds);
+    result.testsDuration.shouldEqual(3.seconds);
 }
 
 

--- a/subpackages/lib/source/odood/lib/odoo/test.d
+++ b/subpackages/lib/source/odood/lib/odoo/test.d
@@ -15,17 +15,18 @@ private import std.exception: enforce;
 private import thepath: Path;
 
 private import odood.lib.project: Project;
-private import odood.utils.odoo.serie: OdooSerie;
+private import odood.lib.odoo.config: getConfVal;
 private import odood.lib.odoo.lodoo: LOdoo;
 private import odood.lib.odoo.log: OdooLogRecord;
 private import odood.lib.odoo.db_manager: OdooDatabaseManager;
-private import odood.utils.addons.addon: OdooAddon;
 private import odood.lib.addons.manager: AddonManager;
 private import odood.lib.addons.repository: AddonRepository;
 private import odood.lib.server: OdooServer, CoverageOptions;
 private import odood.lib.server.log_pipe: OdooLogPipe;
 private import odood.exception: OdoodException;
 private import odood.utils: generateRandomString;
+private import odood.utils.addons.addon: OdooAddon;
+private import odood.utils.odoo.serie: OdooSerie;
 
 // TODO: Make randomized ports
 private immutable ODOO_TEST_HTTP_PORT=8269;
@@ -38,9 +39,8 @@ private immutable ODOO_TEST_LONGPOLLING_PORT=8272;
   *     project = project to generate name of test database for.
   **/
 string generateTestDbName(in Project project) {
-    string prefix = project.getOdooConfig["options"].getKey(
-            "db_user",
-            "odood%s".format(project.odoo.serie.major));
+    string prefix = project.server.getConfig.getConfVal(
+        "db_user", "odood%s".format(project.odoo.serie.major));
     return "%s-odood-test".format(prefix);
 }
 

--- a/subpackages/lib/source/odood/lib/postgres.d
+++ b/subpackages/lib/source/odood/lib/postgres.d
@@ -10,7 +10,7 @@ void createNewPostgresUser(in string user, in string password) {
     // TODO: automatically create separate db user for odood
     //       that could be used to create other users for odoo instances.
     Process("sudo")
-        .setArgs([
+        .withArgs([
             "-u", "postgres", "-H",
             "--",
             "psql", "-c",

--- a/subpackages/lib/source/odood/lib/project/project.d
+++ b/subpackages/lib/source/odood/lib/project/project.d
@@ -15,7 +15,7 @@ private import zipper: Zipper, ZipMode;
 
 private import odood.exception: OdoodException;
 
-private import odood.lib.odoo.config: initOdooConfig, readOdooConfig;
+private import odood.lib.odoo.config: initOdooConfig, readOdooConfig, getConfVal;
 private import odood.lib.odoo.python: guessPySerie, guessVenvOptions;
 private import odood.lib.odoo.lodoo: LOdoo;
 private import odood.lib.server: OdooServer;
@@ -278,18 +278,14 @@ class Project {
       * Returns: Process instance (from theprocess package)
       **/
     auto psql() const {
-        auto odoo_conf = getOdooConfig();
+        auto odoo_conf = server.getConfig();
 
         // TODO: Use resolveProgramPath here
         auto res = Process("psql")
             .withEnv(
-                "PGUSER",
-                odoo_conf["options"].hasKey("db_user") ?
-                    odoo_conf["options"].getKey("db_user") : "odoo")
+                "PGUSER", odoo_conf.getConfVal("db_user", "odoo"))
             .withEnv(
-                "PGPASSWORD",
-                odoo_conf["options"].hasKey("db_password") ?
-                    odoo_conf["options"].getKey("db_password") : "odoo");
+                "PGPASSWORD", odoo_conf.getConfVal("db_password", "odoo"));
 
         if (odoo_conf["options"].hasKey("db_host"))
             res.setEnv(
@@ -583,10 +579,5 @@ class Project {
             this.odoo_install_type,
             serie.guessVenvOptions,
             backup);
-    }
-
-    /// Get configuration for Odoo
-    auto getOdooConfig() const {
-        return this.readOdooConfig;
     }
 }

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -20,7 +20,7 @@ private import odood.lib.project: Project, ProjectServerSupervisor;
 private import odood.utils.odoo.serie: OdooSerie;
 private import odood.exception: OdoodException;
 private import odood.lib.server.exception;
-private import odood.lib.odoo.config: getConfVal;
+private import odood.lib.odoo.config: getConfVal, readOdooConfig;
 private import odood.lib.server.log_pipe;
 private import odood.lib.odoo.log: OdooLogRecord, OdooLogProcessor;
 
@@ -79,6 +79,43 @@ struct OdooServer {
         return _project.venv.path.join("bin", scriptName());
     }
 
+    /// Get path to server configuration file for this server instance
+    @safe pure auto getConfigPath() const {
+        if (_test_mode)
+            return _project.odoo.testconfigfile;
+        else
+            return _project.odoo.configfile;
+    }
+
+    /// Get server configuration
+    auto getConfig() const {
+        return getConfigPath.readOdooConfig;
+    }
+
+    /// Get HTTP url for the server
+    auto getConfigHTTP() const {
+        const struct ServerHTTPInfo {
+            string host;
+            uint port;
+            string url;
+        }
+
+        auto config = getConfig;
+
+        string host = config.getConfVal(
+            _project.odoo.serie >= 11 ? "http_interface" : "xmlrpc_interface",
+            "127.0.0.1");
+        string port = config.getConfVal(
+            _project.odoo.serie >= 11 ? "http_port" : "xmlrpc_port",
+            "8069");
+
+        return ServerHTTPInfo(
+            host: host,
+            port: port.to!uint,
+            url: "http://%s:%s".format(host, port),
+        );
+    }
+
     /** Get PID of running Odoo Process
       * Returns:
       *    - PID of process running
@@ -116,10 +153,7 @@ struct OdooServer {
             foreach(k, v; env) res[k] = v;
 
         string odoo_rc_env_var = _project.odoo.serie > 10 ? "ODOO_RC" : "OPENERP_SERVER";
-        if (_test_mode)
-            res[odoo_rc_env_var] = _project.odoo.testconfigfile.toString;
-        else
-            res[odoo_rc_env_var] = _project.odoo.configfile.toString;
+        res[odoo_rc_env_var] = getConfigPath.toString;
 
         // TODO: Add ability to parse .env files and forward environment variables to Odoo process
         //       This will allow to run Odoo in docker containers and locally in similar way.
@@ -369,20 +403,11 @@ struct OdooServer {
     bool healthcheck(in Duration timeout = 10.seconds) const {
         import requests: Request;
 
-        auto odoo_config = _project.getOdooConfig();
-
-        string host = odoo_config.getConfVal(
-            _project.odoo.serie >= OdooSerie(11) ? "http_interface" : "xmlrpc_interface",
-            "127.0.0.1");
-        string port = odoo_config.getConfVal(
-            _project.odoo.serie >= OdooSerie(11) ? "http_port" : "xmlrpc_port",
-            "8069");
-
         // /web/health exists from Odoo 14; for older versions /web/ responds
         // with 200 or 302 when the server is up.
         string path = _project.odoo.serie >= OdooSerie(14)
             ? "/web/health" : "/web/";
-        string url = "http://%s:%s%s".format(host, port, path);
+        string url = "%s%s".format(getConfigHTTP.url, path);
 
         try {
             auto request = Request();

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -20,6 +20,7 @@ private import odood.lib.project: Project, ProjectServerSupervisor;
 private import odood.utils.odoo.serie: OdooSerie;
 private import odood.exception: OdoodException;
 private import odood.lib.server.exception;
+private import odood.lib.odoo.config: getConfVal;
 private import odood.lib.server.log_pipe;
 private import odood.lib.odoo.log: OdooLogRecord, OdooLogProcessor;
 
@@ -352,6 +353,51 @@ struct OdooServer {
                 break;
         }
     }
+
+    /** Check if the Odoo HTTP server is responding and healthy.
+      *
+      * For Odoo 14+: uses /web/health, expects HTTP 200.
+      * For older Odoo: uses /web/, accepts any HTTP response below 500
+      *     (200 or 302 both indicate Odoo is up).
+      *
+      * Params:
+      *     timeout = HTTP request timeout. Default is 10 seconds.
+      *
+      * Returns:
+      *     true if the server is healthy, false otherwise.
+      **/
+    bool healthcheck(in Duration timeout = 10.seconds) const {
+        import requests: Request;
+
+        auto odoo_config = _project.getOdooConfig();
+
+        string host = odoo_config.getConfVal(
+            _project.odoo.serie >= OdooSerie(11) ? "http_interface" : "xmlrpc_interface",
+            "127.0.0.1");
+        string port = odoo_config.getConfVal(
+            _project.odoo.serie >= OdooSerie(11) ? "http_port" : "xmlrpc_port",
+            "8069");
+
+        // /web/health exists from Odoo 14; for older versions /web/ responds
+        // with 200 or 302 when the server is up.
+        string path = _project.odoo.serie >= OdooSerie(14)
+            ? "/web/health" : "/web/";
+        string url = "http://%s:%s%s".format(host, port, path);
+
+        try {
+            auto request = Request();
+            request.timeout = timeout;
+            auto response = request.get(url);
+            if (_project.odoo.serie >= OdooSerie(14))
+                return response.code == 200;
+            else
+                return response.code < 500;
+        } catch (Exception e) {
+            tracef("Healthcheck failed: %s", e.msg);
+            return false;
+        }
+    }
+
 
     /** Run delegate and gather Odoo errors happened while delegate was running.
       **/

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -440,27 +440,13 @@ struct OdooServer {
             in Duration timeout = 60.seconds,
             in Duration interval = 2.seconds) const {
         import core.time: MonoTime;
-        import peque: Connection;
         import peque.exception: PequeException;
-        import odood.lib.odoo.config: parseOdooDatabaseConfig;
-
-        auto db_conf = _project.parseOdooDatabaseConfig;
-        string[string] db_params = ["dbname": "postgres"];
-        if (db_conf.host)
-            db_params["host"] = db_conf.host;
-        if (db_conf.port)
-            db_params["port"] = db_conf.port;
-        if (db_conf.user)
-            db_params["user"] = db_conf.user;
-        if (db_conf.password)
-            db_params["password"] = db_conf.password;
-        if (db_conf.sslmode)
-            db_params["sslmode"] = db_conf.sslmode;
+        import odood.lib.odoo.db_utils: openPgConnection;
 
         auto deadline = MonoTime.currTime + timeout;
         while (MonoTime.currTime < deadline) {
             try {
-                auto conn = Connection(db_params);
+                _project.openPgConnection("postgres");
                 return true;
             } catch (PequeException e) {
                 tracef("PostgreSQL not ready yet: %s", e.msg);

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -14,15 +14,14 @@ private import std.string: join, strip;
 private import std.algorithm.iteration: map;
 
 private import thepath: Path;
+private import theprocess: Process, isProcessRunning;
 
 private import odood.lib.project: Project, ProjectServerSupervisor;
 private import odood.utils.odoo.serie: OdooSerie;
 private import odood.exception: OdoodException;
-private import odood.utils: isProcessRunning;
 private import odood.lib.server.exception;
 private import odood.lib.server.log_pipe;
 private import odood.lib.odoo.log: OdooLogRecord, OdooLogProcessor;
-private import theprocess: Process;
 
 immutable auto DEFAULT_START_TIMEOUT = 8.seconds;
 

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -424,6 +424,51 @@ struct OdooServer {
     }
 
 
+    /** Wait for PostgreSQL to become available.
+      *
+      * Tries to connect to the PostgreSQL server configured in odoo.conf.
+      * Retries until connected or timeout expires.
+      *
+      * Params:
+      *     timeout  = maximum time to wait. Default 60 seconds.
+      *     interval = time between connection attempts. Default 2 seconds.
+      *
+      * Returns:
+      *     true if PostgreSQL became available within timeout, false otherwise.
+      **/
+    bool waitForPostgres(
+            in Duration timeout = 60.seconds,
+            in Duration interval = 2.seconds) const {
+        import core.time: MonoTime;
+        import peque: Connection;
+        import peque.exception: PequeException;
+        import odood.lib.odoo.config: parseOdooDatabaseConfig;
+
+        auto db_conf = _project.parseOdooDatabaseConfig;
+        string[string] db_params = ["dbname": "postgres"];
+        if (db_conf.host)
+            db_params["host"] = db_conf.host;
+        if (db_conf.port)
+            db_params["port"] = db_conf.port;
+        if (db_conf.user)
+            db_params["user"] = db_conf.user;
+        if (db_conf.password)
+            db_params["password"] = db_conf.password;
+
+        auto deadline = MonoTime.currTime + timeout;
+        while (MonoTime.currTime < deadline) {
+            try {
+                auto conn = Connection(db_params);
+                return true;
+            } catch (PequeException e) {
+                tracef("PostgreSQL not ready yet: %s", e.msg);
+                Thread.sleep(interval);
+            }
+        }
+        return false;
+    }
+
+
     /** Run delegate and gather Odoo errors happened while delegate was running.
       **/
     auto catchOdooErrors(TE=OdoodException)(void delegate () dg) const {

--- a/subpackages/lib/source/odood/lib/server/server.d
+++ b/subpackages/lib/source/odood/lib/server/server.d
@@ -454,6 +454,8 @@ struct OdooServer {
             db_params["user"] = db_conf.user;
         if (db_conf.password)
             db_params["password"] = db_conf.password;
+        if (db_conf.sslmode)
+            db_params["sslmode"] = db_conf.sslmode;
 
         auto deadline = MonoTime.currTime + timeout;
         while (MonoTime.currTime < deadline) {

--- a/subpackages/tipy/source/odood/tipy/package.d
+++ b/subpackages/tipy/source/odood/tipy/package.d
@@ -40,6 +40,56 @@ private static enum supported_lib_names = mixin(bindbc.loader.makeLibPaths(
 ));
 
 
+// Python runtime lifecycle state
+private shared PyThreadState* _py_thread_state = null;
+private shared bool _py_initialized = false;
+
+
+// Boot the Python runtime: load the shared library, initialize the
+// interpreter, enable threading support, and release the GIL.
+// Returns true on success; throws on failure.
+private bool initPyRuntime() {
+    import bindbc.loader;
+    import std.algorithm: map;
+    import std.format: format;
+    import std.string: fromStringz, join;
+
+    auto err_count_start = bindbc.loader.errorCount;
+    if (!loadPyLib()) {
+        auto errors = bindbc.loader.errors[err_count_start .. bindbc.loader.errorCount]
+            .map!((e) => "%s: %s".format(e.error.fromStringz.idup, e.message.fromStringz.idup))
+            .join(",\n");
+        throw new Exception("Cannot load python as library! Errors: %s".format(errors));
+    }
+
+    Py_Initialize();
+    if (!PyEval_ThreadsInitialized())
+        PyEval_InitThreads();
+
+    _py_thread_state = cast(shared PyThreadState*) PyEval_SaveThread();
+    return true;
+}
+
+
+/** Ensure the Python runtime is loaded and initialized exactly once.
+  * Thread-safe via initOnce (double-checked locking).
+  * Subsequent calls after the first are no-ops.
+  **/
+void ensurePyInitialized() {
+    import std.concurrency: initOnce;
+    initOnce!_py_initialized(initPyRuntime());
+}
+
+
+// Shut down the Python runtime at program exit.
+shared static ~this() {
+    if (_py_thread_state)
+        PyEval_RestoreThread(cast(PyThreadState*) _py_thread_state);
+    if (_py_initialized)
+        Py_Finalize();
+}
+
+
 // Load python library
 bool loadPyLib() {
     foreach(libname; supported_lib_names) {

--- a/subpackages/tipy/source/odood/tipy/package.d
+++ b/subpackages/tipy/source/odood/tipy/package.d
@@ -59,6 +59,24 @@ bool loadPyLib() {
 }
 
 
+/** Low-level string extraction that does NOT call pyEnforce or pyEnsureNoError.
+  * Used inside error-handling paths to avoid infinite recursion.
+  * On any nested failure, clears the error and returns a fallback string.
+  **/
+private string pyObjectToStringRaw(PyObject* o) {
+    if (!o) return "<null>";
+    auto unicode = PyObject_Str(o);
+    if (!unicode) { PyErr_Clear(); return "<failed to stringify>"; }
+    scope(exit) Py_DecRef(unicode);
+    auto str = PyUnicode_AsUTF8String(unicode);
+    if (!str) { PyErr_Clear(); return "<failed to encode>"; }
+    scope(exit) Py_DecRef(str);
+    auto cstr = PyBytes_AsString(str);
+    if (!cstr) { PyErr_Clear(); return "<failed to get bytes>"; }
+    return cstr.fromStringz.idup;
+}
+
+
 /** Ensure no python error is set.
   * Checks python error indicator and throw error if such indicator is set.
   *
@@ -75,10 +93,8 @@ void pyEnsureNoError() {
             if (etraceback) Py_DecRef(etraceback);
         }
 
-        // TODO: Think about avoiding usage of convertPyToD
-        //       to avoid possible infinite recursion
-        string msg = etype.convertPyToD!string;
-        if (evalue) msg ~= ": " ~ evalue.convertPyToD!string;
+        string msg = pyObjectToStringRaw(etype);
+        if (evalue) msg ~= ": " ~ pyObjectToStringRaw(evalue);
         throw new Exception(msg);
     }
 }
@@ -96,8 +112,10 @@ void pyEnsureNoError() {
   *     Exception when python object is not valid and some error occured.
   **/
 auto pyEnforce(PyObject* value) {
-    if (!value)
-       pyEnsureNoError();
+    if (!value) {
+        pyEnsureNoError();
+        throw new Exception("Python returned NULL without setting an error indicator");
+    }
     return value;
 }
 
@@ -143,7 +161,7 @@ if (isArray!T && !isSomeString!T) {
         result ~= convertPyToD!(ElementType!T)(item);
     }
 
-    // Ensure python error indicatori is not set
+    // Ensure python error indicator is not set
     pyEnsureNoError();
 
     return result;
@@ -154,7 +172,7 @@ T convertPyToD(T)(PyObject* o)
 if (isFloatingPoint!T) {
     auto number = PyNumber_Float(o).pyEnforce;
     const double result = PyFloat_AsDouble(number);
-    pyEnsureNoError;
+    pyEnsureNoError();
     return result;
 }
 
@@ -196,9 +214,5 @@ auto callPyFunc(T...)(PyObject* fn, T params) {
         PyTuple_SetItem(args, i, params[i].convertToPy);
     }
 
-    //writefln("Call fn %s with args %s and kwargs %s", convertPyToString(fn), convertPyToString(args), convertPyToString(kwargs));
-    auto res = PyObject_Call(fn, args, kwargs);
-    pyEnforce(res);
-    //writefln("Result: %s", res.convertPyToString);
-    return res;
+    return PyObject_Call(fn, args, kwargs).pyEnforce;
 }

--- a/subpackages/tipy/source/odood/tipy/python.d
+++ b/subpackages/tipy/source/odood/tipy/python.d
@@ -45,6 +45,7 @@ mixin(joinFnBinds!false((){
         //PyErr
         {q{PyObject*}, q{PyErr_Occurred}},
         {q{void}, q{PyErr_Fetch}, q{PyObject **ptype, PyObject **pvalue, PyObject **ptraceback}},
+        {q{void}, q{PyErr_Clear}},
 
         // PyDict
         {q{PyObject*}, q{PyDict_New}},
@@ -66,9 +67,6 @@ mixin(joinFnBinds!false((){
 
         // PyIter
         {q{PyObject*}, q{PyIter_Next}, q{PyObject* o}},
-
-        // PyList
-        {q{PyObject*}, q{PyList_AsTuple}, q{PyObject* list}},
 
         // PyBytes
         {q{char*}, q{PyBytes_AsString}, q{PyObject* o}},

--- a/subpackages/utils/dub.sdl
+++ b/subpackages/utils/dub.sdl
@@ -6,7 +6,7 @@ license "MPL-2.0"
 
 dependency "requests" version=">=2.0.0"
 dependency "thepath" version=">=1.2.0"
-dependency "theprocess" version=">=0.0.10"
+dependency "theprocess" version=">=0.1.0"
 dependency "zipper" version=">=0.0.8"
 dependency "versioned" version=">=0.1.0"
 

--- a/subpackages/utils/dub.sdl
+++ b/subpackages/utils/dub.sdl
@@ -6,7 +6,7 @@ license "MPL-2.0"
 
 dependency "requests" version=">=2.0.0"
 dependency "thepath" version=">=1.2.0"
-dependency "theprocess" version=">=0.1.0"
+dependency "theprocess" version=">=0.1.1"
 dependency "zipper" version=">=0.0.8"
 dependency "versioned" version=">=0.1.0"
 

--- a/subpackages/utils/dub.selections.json
+++ b/subpackages/utils/dub.selections.json
@@ -11,7 +11,7 @@
 		"requests": "2.2.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.0.10",
+		"theprocess": "0.1.0",
 		"unit-threaded": "2.2.3",
 		"versioned": "0.1.0",
 		"zipper": "0.0.8"

--- a/subpackages/utils/dub.selections.json
+++ b/subpackages/utils/dub.selections.json
@@ -11,7 +11,7 @@
 		"requests": "2.2.0",
 		"test_allocator": "0.3.4",
 		"thepath": "2.2.0",
-		"theprocess": "0.1.0",
+		"theprocess": "0.1.1",
 		"unit-threaded": "2.2.3",
 		"versioned": "0.1.0",
 		"zipper": "0.0.8"

--- a/subpackages/utils/source/odood/utils/addons/addon.d
+++ b/subpackages/utils/source/odood/utils/addons/addon.d
@@ -75,7 +75,7 @@ final class OdooAddon {
     auto readChangelogEntries(
             in Nullable!Version start_ver=Nullable!Version.init,
             in Nullable!Version end_ver=Nullable!Version.init) const {
-        OdooAddonChangelogEntrie[] result;
+        OdooAddonChangelogEntry[] result;
 
         auto changelog_path = _path.join("changelog");
         if (!changelog_path.exists) {
@@ -85,14 +85,14 @@ final class OdooAddon {
             auto m = matchFirst(
                 p.baseName, `^changelog.(\d+\.\d+\.\d+).md$`);
             if (!m.empty) {
-                auto entrie = OdooAddonChangelogEntrie(m[1], p.readFileText);
-                if (!start_ver.isNull && start_ver.get >= entrie.ver)
-                    // Start ver is defined end entrie version is less than start ver, then skip
+                auto entry = OdooAddonChangelogEntry(m[1], p.readFileText);
+                if (!start_ver.isNull && start_ver.get >= entry.ver)
+                    // Start ver is defined and entry version is less than start ver, then skip
                     continue;
-                if (!end_ver.isNull && end_ver.get < entrie.ver)
-                    /// End ver is defined and etrie version is greater than end ver, then skip
+                if (!end_ver.isNull && end_ver.get < entry.ver)
+                    // End ver is defined and entry version is greater than end ver, then skip
                     continue;
-                result ~= entrie;
+                result ~= entry;
             }
         }
         result.sort!("a > b");  // Sort results

--- a/subpackages/utils/source/odood/utils/addons/addon_changelog.d
+++ b/subpackages/utils/source/odood/utils/addons/addon_changelog.d
@@ -5,8 +5,8 @@ private import std.string: strip;
 private import versioned: Version;
 
 
-/// This struct represents single changelog entries
-struct OdooAddonChangelogEntrie {
+/// This struct represents single changelog entry
+struct OdooAddonChangelogEntry {
     private Version _ver;
     private string _data;
 
@@ -17,17 +17,17 @@ struct OdooAddonChangelogEntrie {
         this._data = data.strip;
     }
 
-    /// Version of this changelog entrie
+    /// Version of this changelog entry
     auto ver() const => _ver;
 
-    /// Data of changelog entrie
+    /// Data of changelog entry
     auto data() const => _data;
 
-    int opCmp(in OdooAddonChangelogEntrie other) {
+    int opCmp(in OdooAddonChangelogEntry other) {
         return this._ver.opCmp(other._ver);
     }
 
-    int opEquals(in OdooAddonChangelogEntrie other) {
+    int opEquals(in OdooAddonChangelogEntry other) {
         return this._ver.opEquals(other._ver);
     }
 }

--- a/subpackages/utils/source/odood/utils/addons/addon_manifest.d
+++ b/subpackages/utils/source/odood/utils/addons/addon_manifest.d
@@ -71,6 +71,8 @@ struct OdooAddonManifest {
 auto parseOdooManifest(in string manifest_content) {
     OdooAddonManifest manifest;
 
+    ensurePyInitialized();
+
     // Acuire python's GIL
     auto gstate = PyGILState_Ensure();
     scope(exit) PyGILState_Release(gstate);
@@ -160,9 +162,10 @@ private shared PyObject* _fn_literal_eval;
 private shared PyThreadState* _py_thread_state;
 private shared bool _py_initialized = false;
 
-// Initialize python interpreter (import ast.literal_eval)
-shared static this() {
-    // TODO: think about lazy initialization of python
+// Load and initialize the Python interpreter, import ast.literal_eval.
+// Returns true on success; throws OdoodException on failure.
+// Called lazily on first use via ensurePyInitialized().
+private bool initPython() {
     import bindbc.loader;
     import std.algorithm: map;
     import std.string: fromStringz, join;
@@ -189,7 +192,14 @@ shared static this() {
     ).pyEnforce;
 
     _py_thread_state = cast(shared PyThreadState*)PyEval_SaveThread();
-    _py_initialized = cast(shared bool)true;
+    return true;
+}
+
+// Ensure Python is initialized exactly once, on first use.
+// Thread-safe via std.concurrency.initOnce (double-checked locking).
+private void ensurePyInitialized() {
+    import std.concurrency: initOnce;
+    initOnce!_py_initialized(initPython());
 }
 
 // Finalize python interpreter (do clean up)

--- a/subpackages/utils/source/odood/utils/addons/addon_manifest.d
+++ b/subpackages/utils/source/odood/utils/addons/addon_manifest.d
@@ -194,6 +194,124 @@ unittest {
     assert(manifest.dependencies == ["base"]);
 }
 
+// Test manifest with price, currency, external_dependencies, tags, and boolean flags
+unittest {
+    const auto manifest = parseOdooManifest(`{
+    'name': "Paid Module",
+    'version': '16.0.1.2.0',
+    'depends': ['base', 'sale'],
+    'author': "Test Author",
+    'category': 'Sales',
+    'summary': 'A paid module',
+    'license': 'OPL-1',
+    'maintainer': 'Maintainer Inc',
+    'application': True,
+    'auto_install': True,
+    'installable': False,
+    'price': 99.99,
+    'currency': 'USD',
+    'tags': ['sales', 'accounting'],
+    'external_dependencies': {
+        'python': ['requests', 'lxml'],
+        'bin': ['wkhtmltopdf'],
+    },
+}`);
+
+    assert(manifest.name == "Paid Module");
+    assert(manifest.module_version.isStandard == true);
+    assert(manifest.module_version.toString == "16.0.1.2.0");
+    assert(manifest.author == "Test Author");
+    assert(manifest.category == "Sales");
+    assert(manifest.summary == "A paid module");
+    assert(manifest.license == "OPL-1");
+    assert(manifest.maintainer == "Maintainer Inc");
+
+    // Boolean flags
+    assert(manifest.application == true);
+    assert(manifest.auto_install == true);
+    assert(manifest.installable == false);
+
+    // Dependencies
+    assert(manifest.dependencies == ["base", "sale"]);
+    assert(manifest.python_dependencies == ["requests", "lxml"]);
+    assert(manifest.bin_dependencies == ["wkhtmltopdf"]);
+
+    // Tags
+    assert(manifest.tags == ["sales", "accounting"]);
+
+    // Price with explicit currency
+    assert(manifest.price.is_set == true);
+    assert(manifest.price.price == 99.99f);
+    assert(manifest.price.currency == "USD");
+
+    import std.algorithm.searching: canFind;
+    assert(manifest.price.toString.canFind("99.99"));
+    assert(manifest.price.toString.canFind("USD"));
+}
+
+// Test manifest with price but no currency (defaults to EUR)
+unittest {
+    const auto manifest = parseOdooManifest(`{
+    'name': "Euro Module",
+    'version': '1.0',
+    'depends': ['base'],
+    'price': 50.0,
+}`);
+
+    assert(manifest.price.is_set == true);
+    assert(manifest.price.price == 50.0f);
+    assert(manifest.price.currency == "EUR");
+}
+
+// Test manifest without price (price.is_set should be false)
+unittest {
+    const auto manifest = parseOdooManifest(`{
+    'name': "Free Module",
+    'version': '1.0',
+    'depends': ['base'],
+}`);
+
+    assert(manifest.price.is_set == false);
+    assert(manifest.price.toString == "");
+}
+
+// Test manifest with default values when fields are missing
+unittest {
+    const auto manifest = parseOdooManifest(`{
+    'name': "Minimal Module",
+}`);
+
+    assert(manifest.name == "Minimal Module");
+    assert(manifest.license == "LGPL-3");  // default
+    assert(manifest.auto_install == false);  // default
+    assert(manifest.application == false);  // default
+    assert(manifest.installable == true);  // default
+    assert(manifest.dependencies == []);
+    assert(manifest.python_dependencies == []);
+    assert(manifest.bin_dependencies == []);
+    assert(manifest.tags == []);
+}
+
+// Test tryParseOdooManifest with invalid content returns null
+unittest {
+    auto result = tryParseOdooManifest("this is not valid python");
+    assert(result.isNull);
+}
+
+// Test OdooAddonManifest.toString
+unittest {
+    import std.algorithm.searching: canFind;
+    const auto manifest = parseOdooManifest(`{
+    'name': "My Addon",
+    'version': '16.0.1.0.0',
+    'depends': ['base'],
+}`);
+
+    auto str = manifest.toString;
+    assert(str.canFind("My Addon"));
+    assert(str.canFind("16.0.1.0.0"));
+}
+
 // Test multithreading
 unittest {
     immutable auto test_manifest = `{

--- a/subpackages/utils/source/odood/utils/addons/addon_manifest.d
+++ b/subpackages/utils/source/odood/utils/addons/addon_manifest.d
@@ -77,7 +77,14 @@ auto parseOdooManifest(in string manifest_content) {
     auto gstate = PyGILState_Ensure();
     scope(exit) PyGILState_Release(gstate);
 
-    auto parsed = callPyFunc(cast(PyObject*)_fn_literal_eval, manifest_content);
+    // ast is cached in sys.modules after the first call, so this is O(1).
+    auto mod_ast = PyImport_ImportModule("ast").pyEnforce;
+    scope(exit) Py_DecRef(mod_ast);
+
+    auto fn_literal_eval = PyObject_GetAttrString(mod_ast, "literal_eval".toStringz).pyEnforce;
+    scope(exit) Py_DecRef(fn_literal_eval);
+
+    auto parsed = callPyFunc(fn_literal_eval, manifest_content);
     scope(exit) Py_DecRef(parsed);
 
     // PyDict_GetItemString returns borrowed reference,
@@ -157,60 +164,6 @@ auto tryParseOdooManifest(in Path path) {
     return tryParseOdooManifest(path.readFileText);
 }
 
-// Module level link to ast module
-private shared PyObject* _fn_literal_eval;
-private shared PyThreadState* _py_thread_state;
-private shared bool _py_initialized = false;
-
-// Load and initialize the Python interpreter, import ast.literal_eval.
-// Returns true on success; throws OdoodException on failure.
-// Called lazily on first use via ensurePyInitialized().
-private bool initPython() {
-    import bindbc.loader;
-    import std.algorithm: map;
-    import std.string: fromStringz, join;
-
-    auto err_count_start = bindbc.loader.errorCount;
-    bool load_status = loadPyLib;
-    if (!load_status) {
-        auto errors = bindbc.loader.errors[err_count_start .. bindbc.loader.errorCount]
-            .map!((e) => "%s: %s".format(e.error.fromStringz.idup, e.message.fromStringz.idup))
-            .join(",\n");
-        throw new OdoodException("Cannot load python as library! Errors: %s".format(errors));
-    }
-
-    Py_Initialize();
-    if (!PyEval_ThreadsInitialized())
-        PyEval_InitThreads();
-
-    auto mod_ast = PyImport_ImportModule("ast");
-    scope(exit) Py_DecRef(mod_ast);
-
-    // Save function literal_eval from ast on module level
-    _fn_literal_eval = cast(shared PyObject*)PyObject_GetAttrString(
-        mod_ast, "literal_eval".toStringz
-    ).pyEnforce;
-
-    _py_thread_state = cast(shared PyThreadState*)PyEval_SaveThread();
-    return true;
-}
-
-// Ensure Python is initialized exactly once, on first use.
-// Thread-safe via std.concurrency.initOnce (double-checked locking).
-private void ensurePyInitialized() {
-    import std.concurrency: initOnce;
-    initOnce!_py_initialized(initPython());
-}
-
-// Finalize python interpreter (do clean up)
-shared static ~this() {
-    if (_py_thread_state)
-        PyEval_RestoreThread(cast(PyThreadState*)_py_thread_state);
-    if (_fn_literal_eval)
-        Py_DecRef(cast(PyObject*)_fn_literal_eval);
-    if (_py_initialized)
-        Py_Finalize();
-}
 
 
 // Tests

--- a/subpackages/utils/source/odood/utils/package.d
+++ b/subpackages/utils/source/odood/utils/package.d
@@ -266,36 +266,3 @@ unittest {
     getCacheDir("cache-42", root.join("default")).shouldEqual(root.join("cache-root", "cache-42"));
     getCacheDir("cache-42", root.join("default")).isAbsolute.shouldBeTrue;
 }
-
-
-/** Check if system user with specified name exists
-  *
-  * Params:
-  *     username = name of user to check if exists
-  * Returns:
-  *     True if such user exists, otherwise false.
-  **/
-bool checkSystemUserExists(in string username) {
-    import core.sys.posix.pwd: getpwnam_r, passwd;
-    import std.exception: errnoEnforce;
-    import std.string: toStringz;
-    import core.stdc.errno: ENOENT, ESRCH, EBADF, EPERM;
-    passwd pwd;
-    passwd* result;
-    long bufsize = 16384;
-    char[] buf = new char[bufsize];
-
-    int s = getpwnam_r(username.toStringz, &pwd, &buf[0], bufsize, &result);
-    if (s == ENOENT || s == ESRCH || s == EBADF || s == EPERM)
-        // Such user does not exists
-        return false;
-
-    errnoEnforce(
-        s == 0,
-        "Got error on attempt to check if user %s exists".format(username));
-
-    if (result)
-        return true;
-
-    return false;
-}

--- a/subpackages/utils/source/odood/utils/package.d
+++ b/subpackages/utils/source/odood/utils/package.d
@@ -5,10 +5,8 @@ module odood.utils;
   **/
 
 private import core.time: Duration, seconds;
-private import core.sys.posix.sys.types: pid_t;
 private import core.thread: Thread;
 private import std.logger: warningf;
-private import std.process: Pid;
 private import std.exception: enforce, basicExceptionCtors;
 private import std.format: format;
 private import std.random: uniform;
@@ -44,23 +42,6 @@ package(odood) @safe Version parsePythonVersion(in Path interpreter_path) {
         "Cannot parse python interpreter (%s) version '%s'".format(
             interpreter_path, python_version_raw));
     return Version(re_match[1]);
-}
-
-
-/// Check if process is alive
-bool isProcessRunning(in pid_t pid) {
-    import core.sys.posix.signal: kill;
-    import core.stdc.errno;
-
-    const int res = kill(pid, 0);
-    if (res == -1 && errno == ESRCH)
-        return false;
-    return true;
-}
-
-/// ditto
-bool isProcessRunning(scope Pid pid) {
-    return isProcessRunning(pid.osHandle);
 }
 
 


### PR DESCRIPTION
### Added

- Added `odood server healthcheck` command. One step to make Odood container-friendly.
- Added `odood server wait-pg` command
- Added `odood server run --wait-pg` option
- Added `odood db is-initialized` command to check if database is already initialized.
- Added `odood db ensure-initialized` command to  initialize database if it is not initialized yet.
- Added new options to `odood addons install`
    - `--missing-only` - install only addons that are not installed in specified db from the list.
    - `--ignore-unfinished-updates` - do not fail on unfinished updates
- Added new options to `odood addons update`
    - `--installed-only` - install only addons that are not installed in specified db from the list.
    - `--ignore-unfinished-updates` - do not fail on unfinished updates
- Added `--tls12-compat` flag to `odood deploy` to allow TLS 1.2 in addition
  to TLS 1.3 for backward compatibility with older clients.
- Added `--use-system-ca-bundle` flag to `odood deploy` to set
  `REQUESTS_CA_BUNDLE` to the system CA certificate store. Auto-detects
  the CA bundle path across Debian/Ubuntu, RHEL/CentOS/Fedora, and openSUSE.


### Changed

- Changed template for `nginx` configuration for `deploy` command:
    - Added security headers
    - Database manager (`/web/database`) is blocked by default
    - Bugfixes related to nginx config generation
- Nginx SSL configuration now defaults to TLS 1.3 only with hardened cipher
  suites (FIPS 140-2/3 compliant, no CBC/RC4/3DES). Use `--tls12-compat`
  to enable TLS 1.2 with ECDHE forward secrecy ciphers.
- Command `odood db list` rewritten in D (no more python / lodoo call)
- Commands `odood addons install` and `odood addons update` now will
  fail if there are unfinished addon updates before running command or after.
  This way these commands ensures clean state of db before and after operation.
- Default dockerimage's command now waits when pg is ready before running Odoo (`odood server run --wait-pg` insteand of `odood server run`)
- "No access rules" warnings are no longer treated as test errors. Models
  that intentionally have no ACLs (e.g. sudo()-only technical models) will
  no longer cause `odood test` to fail.


### Fixed
- Odood now will handle `db_sslmode` parameter correctly inside it's internal database interactions
